### PR TITLE
[WIP] Go-to Definition Frontend

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		6BA1873B1FDDD7B6008220DA /* XiClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA1873A1FDDD7B6008220DA /* XiClipView.swift */; };
 		6BF9575B1FD70C420010BAE6 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF9575A1FD70C420010BAE6 /* Client.swift */; };
 		832910D920229C2D0042C32B /* Fps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832910D820229C2D0042C32B /* Fps.swift */; };
+		96CD2EE1212A5C330074621A /* DefinitionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CD2EDF212A5C330074621A /* DefinitionViewController.swift */; };
+		96CD2EE4212A5E7B0074621A /* DefinitionTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CD2EE3212A5E7B0074621A /* DefinitionTableView.swift */; };
 		AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0243F51E4BDF8A00641BDA /* StyleMap.swift */; };
 		AE041BA61D4327EB0069AB8B /* plugins in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* plugins */; };
 		AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE168C5B1E4AD87B008249AE /* LineCache.swift */; };
@@ -88,6 +90,8 @@
 		6BA1873A1FDDD7B6008220DA /* XiClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiClipView.swift; sourceTree = "<group>"; };
 		6BF9575A1FD70C420010BAE6 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		832910D820229C2D0042C32B /* Fps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fps.swift; sourceTree = "<group>"; };
+		96CD2EDF212A5C330074621A /* DefinitionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionViewController.swift; sourceTree = "<group>"; };
+		96CD2EE3212A5E7B0074621A /* DefinitionTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionTableView.swift; sourceTree = "<group>"; };
 		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* plugins */ = {isa = PBXFileReference; lastKnownFileType = text; path = plugins; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -197,6 +201,8 @@
 				E1288E7F20B06E9C0068EEB9 /* StatusBar.swift */,
 				832910D820229C2D0042C32B /* Fps.swift */,
 				E16BB89720FE42A600A0D7A1 /* HoverViewController.swift */,
+				96CD2EE3212A5E7B0074621A /* DefinitionTableView.swift */,
+				96CD2EDF212A5C330074621A /* DefinitionViewController.swift */,
 				AE499DD61C82BB2B002D68AF /* Info.plist */,
 				F53EA2AC1DCAA8110071ACFD /* Main.storyboard */,
 				AE499DD11C82BB2B002D68AF /* Assets.xcassets */,
@@ -426,6 +432,7 @@
 				6083722F2058597B00E9CF5D /* ShadowView.swift in Sources */,
 				50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */,
 				E1288E8020B06E9C0068EEB9 /* StatusBar.swift in Sources */,
+				96CD2EE4212A5E7B0074621A /* DefinitionTableView.swift in Sources */,
 				AEC4F6CA1FFB02F10060E10E /* Trace.swift in Sources */,
 				6BF9575B1FD70C420010BAE6 /* Client.swift in Sources */,
 				AED23F181C83CBED002246CE /* EditView.swift in Sources */,
@@ -440,6 +447,7 @@
 				AED22D781FE8404D0096E7C3 /* Renderer.swift in Sources */,
 				6BA1873B1FDDD7B6008220DA /* XiClipView.swift in Sources */,
 				AED22D7A1FE8418A0096E7C3 /* Atlas.swift in Sources */,
+				96CD2EE1212A5C330074621A /* DefinitionViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -341,6 +341,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
+    func showDefinition(viewIdentifier: String, requestIdentifier: Int, result: [String: AnyObject]) {
+        let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
+        DispatchQueue.main.async {
+            document?.editViewController?.showDefinition(withResult: result)
+        }
+    }
+
     func configChanged(viewIdentifier: ViewIdentifier, changes: [String : AnyObject]) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -341,7 +341,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
-    func showDefinition(viewIdentifier: String, requestIdentifier: Int, result: [String: AnyObject]) {
+    func showDefinition(viewIdentifier: String, requestIdentifier: Int, result: [[String: AnyObject]]) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
             document?.editViewController?.showDefinition(withResult: result)

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -341,10 +341,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
-    func showDefinition(viewIdentifier: String, requestIdentifier: Int, result: [[String: AnyObject]]) {
+    func handleDefinition(viewIdentifier: String, requestIdentifier: Int, result: [[String: AnyObject]]) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
-            document?.editViewController?.showDefinition(withResult: result)
+            document?.editViewController?.handleDefinition(withResult: result)
         }
     }
 

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -64,6 +64,9 @@ protocol XiClient: AnyObject {
     /// A result, formatted in Markdown, that is returned from a hover request.
     func showHover(viewIdentifier: String, requestIdentifier: Int, result: String)
 
+    /// A notification for the client to open a go-to definition view, returned from a go-to definition request.
+    func showDefinition(viewIdentifier: String, requestIdentifier: Int, result: [String: AnyObject])
+
     /// A notification containing changes to the current config for the given view.
     /// - Note: The first time this message is sent, `changes` contains all defined
     // config keys and their values. Subsequent calls contain only those items which

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -65,7 +65,7 @@ protocol XiClient: AnyObject {
     func showHover(viewIdentifier: String, requestIdentifier: Int, result: String)
 
     /// A notification for the client to open a go-to definition view, returned from a go-to definition request.
-    func showDefinition(viewIdentifier: String, requestIdentifier: Int, result: [String: AnyObject])
+    func showDefinition(viewIdentifier: String, requestIdentifier: Int, result: [[String: AnyObject]])
 
     /// A notification containing changes to the current config for the given view.
     /// - Note: The first time this message is sent, `changes` contains all defined

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -65,7 +65,7 @@ protocol XiClient: AnyObject {
     func showHover(viewIdentifier: String, requestIdentifier: Int, result: String)
 
     /// A notification for the client to open a go-to definition view, returned from a go-to definition request.
-    func showDefinition(viewIdentifier: String, requestIdentifier: Int, result: [[String: AnyObject]])
+    func handleDefinition(viewIdentifier: String, requestIdentifier: Int, result: [[String: AnyObject]])
 
     /// A notification containing changes to the current config for the given view.
     /// - Note: The first time this message is sent, `changes` contains all defined

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -334,6 +334,11 @@ class CoreConnection {
             let requestIdentifier = params["request_id"] as! Int
             let result = params["result"] as! String
             client?.showHover(viewIdentifier: viewIdentifier!, requestIdentifier: requestIdentifier, result: result)
+
+        case "show_definition":
+            let requestIdentifier = params["request_id"] as! Int
+            let result = params["result"] as! [[String: AnyObject]]
+            client?.showDefinition(viewIdentifier: viewIdentifier!, requestIdentifier: requestIdentifier, result: result)
             
         case "find_status":
             let status = params["queries"] as! [[String: AnyObject]]

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -335,10 +335,10 @@ class CoreConnection {
             let result = params["result"] as! String
             client?.showHover(viewIdentifier: viewIdentifier!, requestIdentifier: requestIdentifier, result: result)
 
-        case "show_definition":
+        case "handle_definition":
             let requestIdentifier = params["request_id"] as! Int
             let result = params["result"] as! [[String: AnyObject]]
-            client?.showDefinition(viewIdentifier: viewIdentifier!, requestIdentifier: requestIdentifier, result: result)
+            client?.handleDefinition(viewIdentifier: viewIdentifier!, requestIdentifier: requestIdentifier, result: result)
             
         case "find_status":
             let status = params["queries"] as! [[String: AnyObject]]

--- a/XiEditor/DefinitionTableView.swift
+++ b/XiEditor/DefinitionTableView.swift
@@ -1,0 +1,89 @@
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Cocoa
+
+class DefinitionTableView: NSTableView {
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+    }
+}
+
+class DefinitionTableRowView: NSTableRowView {
+    @IBOutlet weak var methodField: NSTextField!
+    @IBOutlet weak var locationField: NSTextField!
+
+    // MARK: - Mouse hover effect
+    deinit {
+        removeTrackingArea(trackingArea)
+    }
+
+    private var trackingArea: NSTrackingArea!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        NSColor.alternateSelectedControlColor.set()
+        // Fill on mouse hover
+        if hover {
+            let path = NSBezierPath(rect: bounds)
+            path.fill()
+            self.methodField.textColor = NSColor.alternateSelectedControlTextColor
+            self.locationField.textColor = NSColor.alternateSelectedControlTextColor
+        } else {
+            self.methodField.textColor = NSColor.textColor
+            self.locationField.textColor = NSColor.textColor
+        }
+    }
+
+    override func drawSelection(in dirtyRect: NSRect) {
+        super.drawSelection(in: dirtyRect)
+
+        NSColor.alternateSelectedControlColor.set()
+        let rect = NSRect(x: 0, y: bounds.height - 2, width: bounds.width, height: bounds.height)
+        let path = NSBezierPath(rect: rect)
+        path.fill()
+    }
+
+    private var hover = false {
+        didSet {
+            setNeedsDisplay(bounds)
+        }
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        if !hover {
+            hover = true
+        }
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        if hover {
+            hover = false
+        }
+    }
+}

--- a/XiEditor/DefinitionViewController.swift
+++ b/XiEditor/DefinitionViewController.swift
@@ -75,8 +75,8 @@ class DefinitionViewController: NSViewController, NSTableViewDataSource, NSTable
 extension EditViewController {
 
     // Puts the popover at the baseline of the chosen defintition symbol.
-    func showDefinition(withResult result: [String: AnyObject]) {
-        let locations = result["locations"] as! [[String: AnyObject]]
+    func showDefinition(withResult result: [[String: AnyObject]]) {
+        let locations = result
 
         definitionViewController.resultURIs.removeAll()
         definitionViewController.resultPositions.removeAll()
@@ -85,7 +85,7 @@ extension EditViewController {
             let range = location["range"]
             let newPosition = BufferPosition(range!["start"] as! Int, range!["end"] as! Int)
 
-            definitionViewController.resultURIs.append(location["document_uri"] as! String)
+            definitionViewController.resultURIs.append(location["file_uri"] as! String)
             definitionViewController.resultPositions.append(newPosition)
         }
 

--- a/XiEditor/DefinitionViewController.swift
+++ b/XiEditor/DefinitionViewController.swift
@@ -1,0 +1,106 @@
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Cocoa
+
+class DefinitionViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate {
+
+    @IBOutlet weak var resultTableView: DefinitionTableView!
+    var resultURIs = [String]()
+    var resultPositions = [BufferPosition]()
+
+    // Value to pad the definition content width.
+    let contentTextPadding: CGFloat = 50
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        resultTableView.dataSource = self
+        resultTableView.delegate = self
+    }
+
+    // Force view controller to load all its views - including the table view.
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        _ = self.view
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        return resultPositions.count
+    }
+
+    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        if resultPositions.isEmpty {
+            return nil
+        }
+        let line = resultPositions[row].line
+        let column = resultPositions[row].column
+
+        if let cell = tableView.makeView(withIdentifier: .init("DefinitionCellView"), owner: nil) as? DefinitionTableRowView {
+            cell.methodField.stringValue = resultURIs[row]
+            cell.locationField.stringValue = "Line: \(line) Column: \(column)"
+            return cell
+        }
+        return nil
+    }
+
+    func widthToFitContents() -> CGFloat {
+        var longest: CGFloat = 0
+
+        for row in 0..<resultTableView.numberOfRows {
+            let view = resultTableView.rowView(atRow: row, makeIfNecessary: true) as! DefinitionTableRowView
+            let width = ceil(view.methodField.attributedStringValue.size().width + contentTextPadding)
+            if longest < width { longest = width }
+        }
+
+        // We only have one column
+        resultTableView.tableColumns.first?.width = longest
+        resultTableView.reloadData()
+
+        return longest
+    }
+}
+
+extension EditViewController {
+
+    // Puts the popover at the baseline of the chosen defintition symbol.
+    func showDefinition(withResult result: [String: AnyObject]) {
+        let locations = result["locations"] as! [[String: AnyObject]]
+
+        definitionViewController.resultURIs.removeAll()
+        definitionViewController.resultPositions.removeAll()
+
+        for location in locations {
+            let range = location["range"]
+            let newPosition = BufferPosition(range!["start"] as! Int, range!["end"] as! Int)
+
+            definitionViewController.resultURIs.append(location["document_uri"] as! String)
+            definitionViewController.resultPositions.append(newPosition)
+        }
+
+        let definitionContentSize = NSSize(width: definitionViewController.widthToFitContents(), height: definitionViewController.resultTableView.frame.size.height)
+
+        infoPopover.contentViewController = definitionViewController
+        infoPopover.contentSize = definitionContentSize
+
+        if let event = definitionEvent {
+            let definitionLine = editView.bufferPositionFromPoint(event.locationInWindow).line
+            let symbolBaseline = editView.lineIxToBaseline(definitionLine) * CGFloat(definitionLine)
+            let positioningPoint = NSPoint(x: event.locationInWindow.x, y: editView.frame.height - symbolBaseline)
+            let positioningSize = CGSize(width: 1, height: 1) // Generic size to center popover on cursor
+            infoPopover.show(relativeTo: NSRect(origin: positioningPoint, size: positioningSize), of: self.view, preferredEdge: .minY)
+            definitionEvent = nil
+        }
+    }
+}

--- a/XiEditor/DefinitionViewController.swift
+++ b/XiEditor/DefinitionViewController.swift
@@ -78,6 +78,15 @@ extension EditViewController {
     func showDefinition(withResult result: [[String: AnyObject]]) {
         let locations = result
 
+        // Shows message if locations are empty.
+        if locations.count == 0 {
+            let emptyDefinitionResult = "No definition location found."
+            hoverEvent = definitionEvent
+            showHover(withResult: emptyDefinitionResult)
+            definitionEvent = nil
+            return
+        }
+
         definitionViewController.resultURIs.removeAll()
         definitionViewController.resultPositions.removeAll()
 

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -238,6 +238,16 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         self.showBlinkingCursor = self.isFrontmostView && self.isFirstResponder
     }
 
+    // Adds tracking areas for the edit view, used to check for mouse hovers on definition.
+    override func updateTrackingAreas() {
+        for area in self.trackingAreas {
+            self.removeTrackingArea(area)
+        }
+        let newTrackingArea = NSTrackingArea(rect: self.bounds, options: [.activeInActiveApp, .mouseMoved], owner: self, userInfo: nil)
+        self.addTrackingArea(newTrackingArea)
+        super.updateTrackingAreas()
+    }
+
     // MARK: - NSTextInputClient protocol
     func insertText(_ aString: Any, replacementRange: NSRange) {
         self.removeMarkedText()

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -499,7 +499,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
             }
         } else if (event.modifierFlags.contains(NSEvent.ModifierFlags.shift)) {
             return "range_select"
-        } else if (event.modifierFlags.contains(NSEvent.ModifierFlags.command)) {
+        } else if (event.modifierFlags.contains(NSEvent.ModifierFlags.control)) {
             return "request_definition"
         } else if (event.modifierFlags.contains(NSEvent.ModifierFlags.option)) {
             return "request_hover"
@@ -530,6 +530,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         if gestureType == "request_hover" {
             hoverEvent = theEvent
             sendHover()
+        } else if gestureType == "request_definition"  {
+            definitionEvent = theEvent
+            sendDefinitionRequest()
         } else {
             document.sendRpcAsync("gesture", params: [
                 "line": position.line,

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -1073,11 +1073,11 @@ Gw
                             <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="53" horizontalPageScroll="10" verticalLineScroll="53" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mnO-RR-3qD">
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="291"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="lg8-HZ-6IL">
-                                    <rect key="frame" x="0.0" y="25" width="600" height="266"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="291"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="51" rowSizeStyle="automatic" headerView="NuK-sq-BhA" viewBased="YES" floatsGroupRows="NO" id="RWi-3T-K0a" customClass="DefinitionTableView" customModule="XiEditor" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="266"/>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="51" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="RWi-3T-K0a" customClass="DefinitionTableView" customModule="XiEditor" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="291"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1128,8 +1128,8 @@ Gw
                                                                 <constraint firstItem="pMR-3s-Zy9" firstAttribute="centerX" secondItem="mN7-DF-HaQ" secondAttribute="centerX" id="zbW-O5-glX"/>
                                                             </constraints>
                                                             <connections>
-                                                                <outlet property="locationField" destination="giy-3h-ypC" id="pon-0K-N7I"/>
-                                                                <outlet property="methodField" destination="pMR-3s-Zy9" id="7Jw-4a-nqy"/>
+                                                                <outlet property="locationField" destination="giy-3h-ypC" id="Kog-Yw-nbB"/>
+                                                                <outlet property="methodField" destination="pMR-3s-Zy9" id="5Ik-5e-FWZ"/>
                                                             </connections>
                                                         </tableCellView>
                                                     </prototypeCellViews>
@@ -1147,10 +1147,6 @@ Gw
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <tableHeaderView key="headerView" id="NuK-sq-BhA">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="25"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </tableHeaderView>
                             </scrollView>
                         </subviews>
                         <constraints>
@@ -1161,7 +1157,7 @@ Gw
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="resultTableView" destination="RWi-3T-K0a" id="ypc-Jx-gkw"/>
+                        <outlet property="resultTableView" destination="RWi-3T-K0a" id="njX-aA-XYv"/>
                     </connections>
                 </viewController>
             </objects>

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -183,7 +183,7 @@ Gw
         <scene sceneID="CRJ-r2-SVm">
             <objects>
                 <viewController storyboardIdentifier="Find View Controller" id="lKE-xV-0EG" customClass="FindViewController" customModule="XiEditor" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" id="NrM-ac-2ZW" wantsLayer="YES">
+                    <view key="view" wantsLayer="YES" id="NrM-ac-2ZW">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="56"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
@@ -1060,6 +1060,112 @@ Gw
                 <userDefaultsController id="yco-8S-n0A"/>
             </objects>
             <point key="canvasLocation" x="-295" y="-593"/>
+        </scene>
+        <!--Definition View Controller-->
+        <scene sceneID="hpf-6r-L27">
+            <objects>
+                <customObject id="5wJ-ap-jVH" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <viewController storyboardIdentifier="Definition View Controller" id="r9G-73-ibf" userLabel="Definition View Controller" customClass="DefinitionViewController" customModule="XiEditor" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="CiA-GD-kAT">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="289"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="53" horizontalPageScroll="10" verticalLineScroll="53" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mnO-RR-3qD">
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="291"/>
+                                <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="lg8-HZ-6IL">
+                                    <rect key="frame" x="0.0" y="25" width="600" height="266"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="51" rowSizeStyle="automatic" headerView="NuK-sq-BhA" viewBased="YES" floatsGroupRows="NO" id="RWi-3T-K0a" customClass="DefinitionTableView" customModule="XiEditor" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="266"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <size key="intercellSpacing" width="3" height="2"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                            <tableColumns>
+                                                <tableColumn identifier="" editable="NO" width="597" minWidth="40" maxWidth="1000" id="Tc6-om-EQ4">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Definition">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="mcm-hT-TKZ">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView identifier="DefinitionCellView" id="mN7-DF-HaQ" customClass="DefinitionTableRowView" customModule="XiEditor" customModuleProvider="target">
+                                                            <rect key="frame" x="1" y="1" width="597" height="51"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="pMR-3s-Zy9">
+                                                                    <rect key="frame" x="13" y="23" width="571" height="23"/>
+                                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="main()" usesSingleLineMode="YES" id="I8B-iO-g4H">
+                                                                        <font key="font" size="15" name="Menlo-Regular"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="giy-3h-ypC">
+                                                                    <rect key="frame" x="13" y="5" width="571" height="18"/>
+                                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="rust.rs - 104:30" usesSingleLineMode="YES" id="h95-t0-nj5">
+                                                                        <font key="font" size="12" name="Menlo-Regular"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstAttribute="trailing" secondItem="pMR-3s-Zy9" secondAttribute="trailing" constant="15" id="70B-ts-XqY"/>
+                                                                <constraint firstAttribute="bottom" secondItem="giy-3h-ypC" secondAttribute="bottom" constant="5" id="7Y4-Jp-RCI"/>
+                                                                <constraint firstItem="pMR-3s-Zy9" firstAttribute="leading" secondItem="mN7-DF-HaQ" secondAttribute="leading" constant="15" id="Aca-Gg-rpr"/>
+                                                                <constraint firstItem="pMR-3s-Zy9" firstAttribute="leading" secondItem="giy-3h-ypC" secondAttribute="leading" id="Rno-5R-gIS"/>
+                                                                <constraint firstItem="pMR-3s-Zy9" firstAttribute="trailing" secondItem="giy-3h-ypC" secondAttribute="trailing" id="aVi-xe-erT"/>
+                                                                <constraint firstItem="giy-3h-ypC" firstAttribute="top" secondItem="pMR-3s-Zy9" secondAttribute="bottom" id="c6O-cf-D9v"/>
+                                                                <constraint firstItem="pMR-3s-Zy9" firstAttribute="top" secondItem="mN7-DF-HaQ" secondAttribute="top" constant="5" id="dza-De-oa4"/>
+                                                                <constraint firstItem="pMR-3s-Zy9" firstAttribute="centerX" secondItem="mN7-DF-HaQ" secondAttribute="centerX" id="zbW-O5-glX"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <outlet property="locationField" destination="giy-3h-ypC" id="pon-0K-N7I"/>
+                                                                <outlet property="methodField" destination="pMR-3s-Zy9" id="7Jw-4a-nqy"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                            </tableColumns>
+                                        </tableView>
+                                    </subviews>
+                                    <nil key="backgroundColor"/>
+                                </clipView>
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="1Bg-Pp-fOm">
+                                    <rect key="frame" x="1" y="272" width="478" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="37m-Hg-APL">
+                                    <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <tableHeaderView key="headerView" id="NuK-sq-BhA">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="25"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableHeaderView>
+                            </scrollView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="mnO-RR-3qD" firstAttribute="top" secondItem="CiA-GD-kAT" secondAttribute="top" constant="-2" id="Fim-eC-74Y"/>
+                            <constraint firstAttribute="trailing" secondItem="mnO-RR-3qD" secondAttribute="trailing" id="GwJ-es-DJl"/>
+                            <constraint firstAttribute="bottom" secondItem="mnO-RR-3qD" secondAttribute="bottom" id="dRE-nS-PTW"/>
+                            <constraint firstItem="mnO-RR-3qD" firstAttribute="leading" secondItem="CiA-GD-kAT" secondAttribute="leading" id="mD6-Mf-e6x"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="resultTableView" destination="RWi-3T-K0a" id="ypc-Jx-gkw"/>
+                    </connections>
+                </viewController>
+            </objects>
+            <point key="canvasLocation" x="999" y="75.5"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
Tying up loose ends from GSoC, here's the work on the go-to definition frontend. 

Part of #176 
To be used with xi-editor's [#777](https://github.com/google/xi-editor/pull/777)

There's still a lot to be done, such as:

- [ ] Opening a definition result on select
- [ ] Handle cases where definitions are duplicated in many files
- [ ] General UX polish