### PR TITLE
Bugfix: prevent crashing when opening second document

### DIFF
--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -77,10 +77,10 @@ class Document: NSDocument {
         windowController.window?.minSize = Document.minWinSize
 
         self.editViewController = windowController.contentViewController as? EditViewController
+        editViewController?.document = self
         if let config = (NSApplication.shared.delegate as? AppDelegate)?.configCache {
             editViewController?.configChanged(changes: config)
         }
-        editViewController?.document = self
         windowController.window?.delegate = editViewController
         self.addWindowController(windowController)
     }


### PR DESCRIPTION
This is a fix for https://github.com/xi-editor/xi-mac/issues/272