### PR TITLE
[WIP] Add macOS 10.14 Dark Mode support

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -148,11 +148,15 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
                 statusBar.updateStatusBarColor(newBackgroundColor: self.theme.background, newTextColor: self.theme.foreground, newUnifiedTitlebar: unifiedTitlebar)
                 findViewController.updateColor(newBackgroundColor: self.theme.background, unifiedTitlebar: unifiedTitlebar)
-
-                if color.isDark && unifiedTitlebar {
-                    window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
+                
+                if #available(OSX 10.14, *) {
+                    // Let system decide, disregarding active theme color
                 } else {
-                    window.appearance = NSAppearance(named: NSAppearance.Name.aqua)
+                    if color.isDark && unifiedTitlebar {
+                        window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
+                    } else {
+                        window.appearance = NSAppearance(named: NSAppearance.Name.aqua)
+                    }
                 }
             }
         }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -50,6 +50,8 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
     @IBOutlet weak var editViewHeight: NSLayoutConstraint!
     @IBOutlet weak var editViewWidth: NSLayoutConstraint!
+    
+    let appDelegate = NSApp.delegate as! AppDelegate
 
     lazy var findViewController: FindViewController! = {
         let storyboard = NSStoryboard(name: NSStoryboard.Name(rawValue: "Main"), bundle: nil)
@@ -618,6 +620,11 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     // MARK: - Debug Methods
     @IBAction func debugSetTheme(_ sender: NSMenuItem) {
         guard sender.state != NSControl.StateValue.on else { print("theme already active"); return }
+        if sender.title == "macOS" {
+            let theme = Theme.systemTheme()
+            appDelegate.themeChanged(name: sender.title, theme: theme)
+            return
+        }
         let req = Events.SetTheme(themeName: sender.title)
         document.dispatcher.coreConnection.sendRpcAsync(req.method, params: req.params!)
     }
@@ -759,6 +766,12 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
             .first?.title
 
         pluginsMenu.removeAllItems()
+        
+        let systemThemeMenuItem = NSMenuItem(title: "macOS", action: #selector(EditViewController.debugSetTheme(_:)), keyEquivalent: "")
+        systemThemeMenuItem.state = NSControl.StateValue(rawValue: ("macOS" == currentlyActive) ? 1 : 0)
+        
+        pluginsMenu.addItem(systemThemeMenuItem)
+        pluginsMenu.addItem(NSMenuItem.separator())
         for theme in themes {
             let item = NSMenuItem(title: theme, action: #selector(EditViewController.debugSetTheme(_:)), keyEquivalent: "")
             item.state = NSControl.StateValue(rawValue: (theme == currentlyActive) ? 1 : 0)

--- a/XiEditor/Theme.swift
+++ b/XiEditor/Theme.swift
@@ -75,6 +75,29 @@ extension Theme {
               shadow: nil
             )
     }
+    
+    static func systemTheme() -> Theme {
+        if #available(OSX 10.13, *) {
+            return Theme(foreground: NSColor.textColor,
+                         background: NSColor.textBackgroundColor,
+                         caret: NSColor.red, // Seems to be ignored
+                         lineHighlight: NSColor.green, // Seems to be ignored
+                         findHighlight: NSColor.blue, // Seems to be ignored
+                         findHighlightForeground: NSColor.purple, // Seems to be ignored
+                         gutter: NSColor.textBackgroundColor,
+                         gutterForeground: NSColor.secondaryLabelColor,
+                         selection: NSColor.selectedTextBackgroundColor,
+                         selectionForeground: NSColor.systemPink, // Seems to be ignored
+                         selectionBorder: NSColor.yellow, // Seems to be ignored
+                         inactiveSelection: NSColor.brown, // Seems to be ignored
+                         inactiveSelectionForeground: NSColor.cyan, // Seems to be ignored
+                         shadow: NSColor.magenta // Seems to be ignored
+            )
+        } else {
+            // Fallback on earlier versions
+            return defaultTheme()
+        }
+    }
 
     init(jsonObject dict: [String: AnyObject]) {
         let foreground = NSColor(jsonRgbaColor: dict["foreground"] as? [String: AnyObject] ?? [:])


### PR DESCRIPTION
# WIP

<img width="730" alt="capture d ecran 2018-10-03 a 00 09 52" src="https://user-images.githubusercontent.com/4186230/46380099-5b624000-c6a1-11e8-8b7d-0bb56a0512cd.png">

As suggested in #276 by @jansol and @nangtrongvuon, I'm creating a PR so we can push the discussion further. Bear in mind this is my first contribution to a Swift project. 🙈

This is a work in progress, and should probably not be merged as-is.

## Set theme flow

The Theme changes originally follow this flow during the app lifecycle:
- Select theme
  - App initialization
    - Get theme list from `core`
    - Get current theme from preferences
  - Manual theme setting
     - Get theme name from menu item
- Apply theme
  - Send a *set theme* message to `core`
  - `core` responds to `mac` with a JSON-like theme object
  - The provided theme object is parsed by `mac` and sets the menu item as *active*

### Working stuff

What works in the current PR, is selecting the `macOS` theme after app initialization. Doing so will inhibit the *set theme* message usually sent to `core`, and update the UI with a `Theme` object directly.

### Not working stuff

I found that setting the theme this way does not work for some keys (they are explicitly listed in comments in the code).
Opening the app when `macOS` theme is selected results in an error from `core`, because of the *set theme* message sent on startup with a theme name that does not exist in `core`. We could inhibit this as well.
`core` seems to still have a word to say in what's displayed on the screen somehow, and the previously selected theme will apply to the editor text color.

## Thoughts

As you can see, this PR is pretty hacky, so we may want to come up with a better solution. But I feel this is definitely doable.

I feel the best solution (for a working v1) would be to have a dedicated theme menu entry that is treated like a special case that sends a *set theme* message to core with an existing theme (e.g. `base16-ocean.light`) based on the current selected system color scheme, so the editor can use the text color from core, and then set the rest of the app UI with a Theme object using semantic `NSColors`.

If any of you guys have insights or general tips regarding Swift development please feel free to share your feedback and contribute!

😃