### PR TITLE
Render background colors for text spans

### DIFF
--- a/XiEditor/Theme.swift
+++ b/XiEditor/Theme.swift
@@ -120,8 +120,10 @@ extension Theme {
             var brightness: CGFloat = 0.0
             var alpha: CGFloat = 0.0
             defaultHighlight.usingColorSpaceName(.calibratedRGB)?.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
-            return [defaultHighlight] + (0..<Style.N_RESERVED_STYLES).map({
-                return NSColor(hue: CGFloat((1.0 / Double(Style.N_RESERVED_STYLES)) * Double($0)), saturation: 1, brightness: brightness, alpha: alpha)
+            // Leave room for default highlight and selection colors
+            let customHighlights = Style.N_RESERVED_STYLES - 2
+            return [defaultHighlight] + (0..<customHighlights).map({
+                return NSColor(hue: CGFloat((1.0 / Double(customHighlights)) * Double($0)), saturation: 1, brightness: brightness, alpha: alpha)
             })
         })
     }

--- a/XiEditor/XiTextPlane/Renderer.swift
+++ b/XiEditor/XiTextPlane/Renderer.swift
@@ -241,11 +241,11 @@ class Renderer {
 
     /// Draw line background.
     func drawLineBg(line: TextLine, x0: GLfloat, yRange: Range<GLfloat>) {
-        for selRange in line.selRanges {
-            drawSolidRect(x: x0 + selRange.range.lowerBound, y: yRange.lowerBound,
-                          width: selRange.range.upperBound - selRange.range.lowerBound,
+        for bgRange in line.bgRanges {
+            drawSolidRect(x: x0 + bgRange.range.lowerBound, y: yRange.lowerBound,
+                          width: bgRange.range.upperBound - bgRange.range.lowerBound,
                           height: yRange.upperBound - yRange.lowerBound,
-                          argb: selRange.argb)
+                          argb: bgRange.argb)
         }
     }
 

--- a/XiEditor/XiTextPlane/TextLine.swift
+++ b/XiEditor/XiTextPlane/TextLine.swift
@@ -19,7 +19,7 @@ class TextLineBuilder {
     var attrString: NSMutableAttributedString
     var defaultFgColor: UInt32 = 0xff000000
     var fgSpans: [ColorSpan] = []
-    var selSpans: [ColorSpan] = []
+    var bgSpans: [ColorSpan] = []
     var fakeItalicSpans: [SimpleSpan] = []
     var underlineSpans: [UnderlineSpan] = []
     // Note: the font here is used only to get underline metrics, this may change.
@@ -46,9 +46,9 @@ class TextLineBuilder {
         }
     }
 
-    func addSelSpan(range: CountableRange<Int>, argb: ARGBColor) {
+    func addBgSpan(range: CountableRange<Int>, argb: ARGBColor) {
         if !range.isEmpty {
-            selSpans.append(ColorSpan(range: range, payload: argb))
+            bgSpans.append(ColorSpan(range: range, payload: argb))
         }
     }
 
@@ -125,8 +125,8 @@ class TextLineBuilder {
             }
         }
         var bgRange: [(BackgroundColorRange)] = []
-        for selSpan in selSpans {
-            bgRange.append(BackgroundColorRange(range: getCtLineRange(ctLine, selSpan.range), argb: selSpan.payload))
+        for bgSpan in bgSpans {
+            bgRange.append(BackgroundColorRange(range: getCtLineRange(ctLine, bgSpan.range), argb: bgSpan.payload))
         }
         var underlineRanges: [UnderlineRange] = []
         if !underlineSpans.isEmpty {
@@ -149,7 +149,7 @@ class TextLineBuilder {
                 underlineRanges.append(UnderlineRange(range: range, y: y, argb: argb))
             }
         }
-        return TextLine(glyphs: glyphs, ctLine: ctLine, selRanges: bgRange, underlineRanges: underlineRanges, width: nil)
+        return TextLine(glyphs: glyphs, ctLine: ctLine, bgRanges: bgRange, underlineRanges: underlineRanges, width: nil)
     }
 
     /// Measure the total width of the line. Should be consistent with `.build().width`
@@ -164,15 +164,15 @@ struct TextLine {
     var glyphs: [GlyphInstance]
     // The CTLine is kept mostly for caret queries
     var ctLine: CTLine
-    var selRanges: [BackgroundColorRange]
+    var bgRanges: [BackgroundColorRange]
     var underlineRanges: [UnderlineRange]
     let width: Double
 
-    init(glyphs: [GlyphInstance], ctLine: CTLine, selRanges: [BackgroundColorRange], underlineRanges: [UnderlineRange], width: Double?) {
+    init(glyphs: [GlyphInstance], ctLine: CTLine, bgRanges: [BackgroundColorRange], underlineRanges: [UnderlineRange], width: Double?) {
         self.glyphs = glyphs
         self.width = width ?? CTLineGetTypographicBounds(ctLine, nil, nil, nil)
         self.ctLine = ctLine
-        self.selRanges = selRanges
+        self.bgRanges = bgRanges
         self.underlineRanges = underlineRanges
     }
 
@@ -202,7 +202,7 @@ struct TextLine {
             glyphPosition += 1
         }
 
-        return TextLine(glyphs: newGlyphs, ctLine: ctLine, selRanges: [], underlineRanges: [], width: newWidth);
+        return TextLine(glyphs: newGlyphs, ctLine: ctLine, bgRanges: [], underlineRanges: [], width: newWidth);
     }
 }
 


### PR DESCRIPTION
Depends on xi-editor/xi-editor#894.

Some themes set a red background color for illegal characters. Xi doesn't currently render this, which can make the text illegible. This pull request aims to fix that.

### Complications with blending
My approach here was to simply render theme styles first, then find styles, then selection styles on top. With translucent find highlight and selection colors, this can look alright. Highlights and selections blend with the span's background color, but don't obscure it. Here's a theme I've been using for testing:

[One Light.tmTheme.zip](https://github.com/xi-editor/xi-mac/files/2454265/One.Light.tmTheme.zip)

With an opaque selection color (i.e. with the included syntect themes), this doesn't look so good; selections just override the span's background color. To make existing themes look better, we could add logic to blend only as needed, and use the opaque color the rest of the time. However, if we're moving away from syntect's themes anyway (xi-editor/xi-editor#883), it might make sense to just assume that themes have been adapted for xi.

One other consideration is that the two blending styles will look slightly different. For instance, if a theme wants a white background with a light gray selection color, the selection color could either be an opaque light gray (with custom blending logic) or a translucent dark gray. The former would lighten background spans; the latter (what I did here) darkens them.

Anyway, I'm not totally sure about this. Let me know if I'm headed in the wrong direction.