### PR TITLE
Add recording options to UI

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -431,7 +431,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         }
     }
 
-    //MARK: Default menu items
+    // MARK: - Default menu items
     override func selectAll(_ sender: Any?) {
         editView.unmarkText()
         editView.inputContext?.discardMarkedText()
@@ -480,6 +480,18 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     
     @objc func decreaseNumber(_ sender: Any?) {
         document.sendRpcAsync("decrease_number", params: [])
+    }
+
+    @objc func toggleRecording(_ sender: Any?) {
+        document.sendRpcAsync("toggle_recording", params: ["recording_name": "DEFAULT"])
+    }
+
+    @objc func playRecording(_ sender: Any?) {
+        document.sendRpcAsync("play_recording", params: ["recording_name": "DEFAULT"])
+    }
+
+    @objc func clearRecording(_ sender: Any?) {
+        document.sendRpcAsync("clear_recording", params: ["recording_name": "DEFAULT"])
     }
 
     fileprivate func cutCopy(_ method: String) {

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
-        <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
     </dependencies>
     <scenes>
         <!--Window Controller-->
@@ -125,7 +124,7 @@ DQ
                                 <rect key="frame" x="20" y="20" width="275" height="22"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="zlO-6u-liO">
                                     <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
@@ -862,6 +861,31 @@ Gw
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="capitalizeWord:" target="7er-QZ-amI" id="Zzp-rs-6Ln"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Recording" id="Bwl-n2-eW9">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Recording" id="ZLR-Sj-bWX">
+                                                <items>
+                                                    <menuItem title="Toggle Recording" keyEquivalent="r" id="Aok-yZ-fud">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="toggleRecording:" target="7er-QZ-amI" id="gdz-W1-fqj"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Play Recording" keyEquivalent="p" id="Jra-ai-sCb">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="playRecording:" target="7er-QZ-amI" id="gdz-W2-fqj"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Clear Recording" keyEquivalent="c" id="f6l-Uo-onv">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="clearRecording:" target="7er-QZ-amI" id="gdz-W3-fqj"/>
                                                         </connections>
                                                     </menuItem>
                                                 </items>


### PR DESCRIPTION
Companion PR to https://github.com/xi-editor/xi-editor/pull/873

Adds some simple recording commands to the menu:
- Toggle Recording (Ctrl + Cmd + R)
- Play Recording (Ctrl + Cmd + P)
- Clear Recording (Ctrl + Cmd + C)

The current implementation of recording in `xi-mac` only stores _one_ recording at the moment, even though support for multiple named recording is technically possible. The reason being that user named recordings isn't something explicitly required in order to test the recording feature and the UI for such a thing would be a bit of the pain to add at this stage. Currently, every recording is saved as `DEFAULT`.

A nice to have that maybe we _could_ add (but not really needed at the moment) would be simple  notifications when a performing a recording action. For example, it'd be nice to know you're in recording mode or that you've cleared your current recording.