### PR TITLE
Fix crash when selecting text written in Arabic

### DIFF
--- a/XiEditor/XiTextPlane/TextLine.swift
+++ b/XiEditor/XiTextPlane/TextLine.swift
@@ -271,5 +271,7 @@ func argbToFloats(argb: UInt32) -> (GLfloat, GLfloat, GLfloat, GLfloat) {
 func getCtLineRange(_ ctLine: CTLine, _ range: CountableRange<Int>) -> Range<GLfloat> {
     let start = GLfloat(CTLineGetOffsetForStringIndex(ctLine, range.startIndex, nil))
     let end = GLfloat(CTLineGetOffsetForStringIndex(ctLine, range.endIndex, nil))
-    return Range(uncheckedBounds: (lower: start, upper: end))
+    let lower = min(start, end)
+    let upper = max(start, end)
+    return lower ..< upper
 }

--- a/XiEditor/XiTextPlane/TextLine.swift
+++ b/XiEditor/XiTextPlane/TextLine.swift
@@ -271,5 +271,5 @@ func argbToFloats(argb: UInt32) -> (GLfloat, GLfloat, GLfloat, GLfloat) {
 func getCtLineRange(_ ctLine: CTLine, _ range: CountableRange<Int>) -> Range<GLfloat> {
     let start = GLfloat(CTLineGetOffsetForStringIndex(ctLine, range.startIndex, nil))
     let end = GLfloat(CTLineGetOffsetForStringIndex(ctLine, range.endIndex, nil))
-    return start ..< end
+    return Range(uncheckedBounds: (lower: start, upper: end))
 }


### PR DESCRIPTION
This should fix #263.

Right now the app crashes while selecting text in Arabic using the following snippet:

```
Selecting characters written in English works fine, 
but when I try to select characters written in Arabic, it crashes

The following line is written in Arabic, it's shaped correctly without any issue
هذا السطر مكتوب بالعربية ولا مشكلة في الكتابة أبدًا
```

After the change the crash does not occur.

This is my first contribution to the project. Please be kind and let me know if there's any documentation missing with this one 😄