### PR TITLE
Show hidden files

### DIFF
--- a/XiEditor/XiDocumentController.swift
+++ b/XiEditor/XiDocumentController.swift
@@ -106,6 +106,11 @@ class XiDocumentController: NSDocumentController {
         super.removeDocument(document)
     }
 
+    override func runModalOpenPanel(_ openPanel: NSOpenPanel, forTypes types: [String]?) -> Int {
+        openPanel.showsHiddenFiles = true
+        return super.runModalOpenPanel(openPanel, forTypes: types)
+    }
+    
     override func openDocument(withContentsOf url: URL,
                                display displayDocument: Bool,
                                completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {


### PR DESCRIPTION
## Before

The open dialog would not show hidden files, such as `.travis.yml`

## After

All hidden files are to shown to the user when the open dialog is presented

Note: I'm not an iOS developer, I hope this is roughly correct 🤞 

---

Closes https://github.com/xi-editor/xi-mac/issues/308