### PR TITLE
Make the Multiple Search Queries menu item reflect the active window

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -801,11 +801,20 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
             }
         }
     }
+
+    func updateFindMenu() {
+        let item = NSApplication.shared.mainMenu!
+            .item(withTitle: "Edit")!.submenu!
+            .item(withTitle: "Find")!.submenu!
+            .item(withTitle: "Multiple Search Queries")!
+        item.state = findViewController.showMultipleSearchQueries ? .on : .off
+    }
     
     // Gets called when active window changes
     func updateMenuState() {
         updatePluginMenu()
         updateLanguageMenu()
+        updateFindMenu()
     }
 
     @objc func handleCommand(_ sender: NSMenuItem) {


### PR DESCRIPTION
There used to be a minor issue with the Multiple Search Queries menu item:

1. Enable Multiple Search Queries for one window
2. Switch to a window where it's disabled
3. Open the Edit > Find menu. Multiple Search Queries still has a check mark next to it.

This pull request fixes the issue by updating the menu state whenever the key window changes.