### PR TITLE
[WIP] Add CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 xcuserdata/
 .DS_Store
 build/
+.build/
 .env
 xi-editor/

--- a/xi/Package.resolved
+++ b/xi/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftPM",
+        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
+        "state": {
+          "branch": null,
+          "revision": "235aacc514cb81a6881364b0fedcb3dd083228f3",
+          "version": "0.3.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/xi/Package.swift
+++ b/xi/Package.swift
@@ -1,0 +1,16 @@
+import PackageDescription
+
+let package = Package(
+    name: "xi",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.3.0")
+    ],
+    targets: [
+        .target(
+            name: "xi",
+            dependencies: ["Utility"]),
+        .testTarget(
+            name: "xiTests",
+            dependencies: ["xi"]),
+    ]
+)

--- a/xi/Sources/xi/main.swift
+++ b/xi/Sources/xi/main.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Utility
+
+let parser = ArgumentParser(
+    usage: "<options> [path]",
+    overview: "xi - A modern editor with a backend written in Rust"
+)
+
+let versionArg: OptionArgument<Bool> = parser.add(
+    option: "--version",
+    shortName: "-v",
+    kind: Bool.self,
+    usage: "Print version information."
+)
+
+let helpArg: OptionArgument<Bool> = parser.add(
+    option: "--help",
+    shortName: "-h",
+    kind: Bool.self,
+    usage: "Show this information."
+)
+
+let waitArg: OptionArgument<Bool> = parser.add(
+    option: "--wait",
+    shortName: "-w",
+    kind: Bool.self,
+    usage: "Wait for file to be closed by Xi"
+)
+
+func run(arguments: ArgumentParser.Result) {
+    // TODO: How do we communicate with Xi? Using IPC?
+    if arguments.get(versionArg) != nil {
+        print("TODO: Find the version")
+        exit(0)
+    }
+    else if arguments.get(waitArg) != nil {
+        print("TODO: Open the file/stdin and wait")
+        exit(0)
+    }
+    // TODO: Handle path. E.g. git will invoke using
+    // /<path-to-project>/.git/COMMIT_EDITMSG
+}
+
+do {
+    // The first argument is the executable, which we don't need.
+    let arguments = Array(ProcessInfo.processInfo.arguments.dropFirst())
+    let parsedArguments = try parser.parse(arguments)
+    run(arguments: parsedArguments)
+}
+catch let error as ArgumentParserError {
+    print(error.description)
+    exit(1)
+}
+catch let error {
+    print(error.localizedDescription)
+    exit(2)
+}

--- a/xi/Tests/xiTests/XCTestManifests.swift
+++ b/xi/Tests/xiTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !os(macOS)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(xiTests.allTests),
+    ]
+}
+#endif

--- a/xi/Tests/xiTests/xiTests.swift
+++ b/xi/Tests/xiTests/xiTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import class Foundation.Bundle
+
+final class xiTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        let fooBinary = productsDirectory.appendingPathComponent("xi")
+
+        let process = Process()
+        process.executableURL = fooBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(output, "Hello, world!\n")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}


### PR DESCRIPTION
This is a WIP PR for #313. Opening it now so we can discuss things along the way. Right now it's just a placeholder CLI.

Other editor CLI implementations that we can draw inspiration from

- [mate](https://github.com/textmate/textmate/blob/master/Applications/mate/src/mate.cc) for TextMate
- [code](https://github.com/Microsoft/vscode/blob/master/src/vs/code/node/cli.ts) for VSCode

Things that are missing

- [ ] Tie the CLI into the existing build process
- [ ] Open Xi with the given path
- [ ] Some sort of IPC between the CLI and the Xi app so the app can communicate when a file is closed (to implement the `--wait` flag)