### PR TITLE
Be explicit about non-implemented initWithCoder

### DIFF
--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -34,6 +34,7 @@ class HoverView: NSTextView {
         self.alignment = .justified
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -64,6 +65,7 @@ class HoverViewController: NSViewController {
         self.scrollView.documentView = hoverView
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/XiEditor/Search.swift
+++ b/XiEditor/Search.swift
@@ -547,6 +547,7 @@ class Label: NSTextField {
         self.isBezeled = false
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -45,6 +45,7 @@ class StatusItem: NSTextField {
         self.sizeToFit()
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -104,6 +105,7 @@ class StatusBar: NSView {
         updateStatusBarVisibility()
     }
 
+    @available(*, unavailable)
     required init?(coder decoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/XiEditor/XiTextPlane/TextPlane.swift
+++ b/XiEditor/XiTextPlane/TextPlane.swift
@@ -30,6 +30,7 @@ class TextPlaneDemo: NSView, TextPlaneDelegate {
         layer = glLayer
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("coding not implemented for text plane")
     }
@@ -105,6 +106,7 @@ class TextPlaneLayer : NSOpenGLLayer, FpsObserver {
         super.init(layer: layer)
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }


### PR DESCRIPTION
There are several cases when the Xcode forced the developers to give implementation for `init?(coder: NSCoder)`. Those implementations contain only simple `fatalError` call.
Let's be explicit about the fact, that the initializer declarations aren't currently available.

[Attributes in Swift docs](https://docs.swift.org/swift-book/ReferenceManual/Attributes.html)
