### PR TITLE
Moved xi-editor to Submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,3 @@ xcuserdata/
 
 ### Project Specific ###
 .env
-xi-editor/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "xi-editor"]
+	path = xi-editor
+	url = https://github.com/xi-editor/xi-editor
+	branch = master

--- a/README.md
+++ b/README.md
@@ -35,30 +35,41 @@ Screenshot (will need to be updated as syntax coloring and UI polish is added):
 
 ![xi screenshot](/doc/img/xi-mac-screenshot.png?raw=true)
 
-
 ## Getting started
 
 ### Requirements
+
 - [Xcode 9.x](https://developer.apple.com/xcode/)
 - [Rust](https://www.rust-lang.org/). We test against the latest stable version,
 and recommend installing through [rustup](https://rustup.rs).
 
+### Installing
 
-Note: the front-end and back-end are split into two separate repositories. This
+*Note:* the front-end and back-end are split into two separate repositories. This
 is the front-end, and the back-end (or core) is now in
-[xi-editor](https://github.com/xi-editor/xi-editor). Make sure to have that checked out
-as a subdirectory.
+[xi-editor](https://github.com/xi-editor/xi-editor). It is contained in a submodule that is checked out during the clone command.
 
-```
-> git clone https://github.com/xi-editor/xi-mac
+**Clone the repository:**
+
+```bash
+> git clone --recurse-submodules https://github.com/xi-editor/xi-mac
 > cd xi-mac
-> git clone https://github.com/xi-editor/xi-editor
+```
+
+**Build and Open:**
+
+```bash
 > xcodebuild
 > open build/Release/XiEditor.app
 ```
 
-Or `open XiEditor.xcodeproj` and hit the Run button.
+Or
 
+```bash
+> open XiEditor.xcodeproj
+```
+
+and then hitting the Run button.
 
 ### Troubleshooting
 


### PR DESCRIPTION
This provides:
- One less install step
- Allowing the position of the folder to be moved around and have it definitely recorded in more than the readme
- Guaranteed presence on clone (much harder to mess up install)

While still maintaining the same master tracking master functionality