### PR TITLE
Replace references to IRC with Zulip

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ The xi-editor project follows the Rust Code of Conduct, reproduced below.
 **Contact**: [mods@xi-editor.io](mailto:mods@xi-editor.io)
 
 * We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
-* On Zulip, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+* On chat platforms (like Zulip and IRC), please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
 * Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
@@ -17,7 +17,7 @@ The xi-editor project follows the Rust Code of Conduct, reproduced below.
 
 ## Moderation
 
-These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact a maintainer on Github. To contact a moderator by email, use [mods@xi-editor.io](mailto:mods@xi-editor.io).
+These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact a moderator by email, use [mods@xi-editor.io](mailto:mods@xi-editor.io).
 
 1. Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
 2. Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
@@ -32,7 +32,6 @@ In the Rust community we strive to go the extra step to look out for each other.
 
 And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
 
-The enforcement policies listed above apply to all official xi-editor venues, including the #xi-editor channel on Zulip and the repositories under the
-xi-editor organization.
+The enforcement policies listed above apply to all official xi-editor venues, including Zulip, the #xi channel on IRC, and the repositories under the xi-editor organization.
 
 *Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ The xi-editor project follows the Rust Code of Conduct, reproduced below.
 **Contact**: [mods@xi-editor.io](mailto:mods@xi-editor.io)
 
 * We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
-* On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+* On Zulip, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
 * Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
@@ -17,9 +17,7 @@ The xi-editor project follows the Rust Code of Conduct, reproduced below.
 
 ## Moderation
 
-
-These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact
-a mod (on IRC) or a maintainer (on Github). To contact a moderator by email, use [mods@xi-editor.io](mailto:mods@xi-editor.io).
+These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact a maintainer on Github. To contact a moderator by email, use [mods@xi-editor.io](mailto:mods@xi-editor.io).
 
 1. Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
 2. Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
@@ -34,7 +32,7 @@ In the Rust community we strive to go the extra step to look out for each other.
 
 And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
 
-The enforcement policies listed above apply to all official xi-editor venues, including the #xi irc channel and the repositories under the
+The enforcement policies listed above apply to all official xi-editor venues, including the #xi-editor channel on Zulip and the repositories under the
 xi-editor organization.
 
 *Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,15 +19,15 @@ follow the [Code of Conduct](https://github.com/xi-editor/xi-editor/blob/master/
 
 ## Getting started
 
-Not sure where to start? If you haven't already, take a look at the 
+Not sure where to start? If you haven't already, take a look at the
 [docs](http://xi-editor.github.io/xi-editor/docs.html) to get a better
 sense of the project. Read through some issues and some open PRs, to
-get a sense for the habits of existing contributors. Drop by the #xi
-channel on [irc.mozilla.org](https://mozilla.logbot.info/xi) to follow
-ongoing discussions or ask questions. Clone the repos you're
-interested in, and make sure you can build and run the tests. If you
-can't, open an issue, and someone will try to help. Once you're up and
-running, there are a a number of ways to participate:
+get a sense for the habits of existing contributors. Drop by the #xi-editor
+stream on [Zulip](https://xi.zulipchat.com) (anyone with a Github account can
+easily signup) to follow ongoing discussions or ask questions. Clone the repos
+you're interested in, and make sure you can build and run the tests. If you
+can't, open an issue, and someone will try to help. Once you're up and running,
+there are a a number of ways to participate:
 
 ### Opening issues
 
@@ -41,11 +41,11 @@ and/or examples of how this feature is used in other editors.
 #### Before you open an issue
 
 Before opening an issue, **try to identify where the issue belongs**.
-Is it a problem with the frontend or with core? The frontend is 
+Is it a problem with the frontend or with core? The frontend is
 responsible for drawing windows and UI, and handling events; the core
 is responsible for most everything else. Issues with the frontend
 should be opened in that frontend's repository, and issues with
-core should be opened in the 
+core should be opened in the
 [xi-editor](https://github.com/xi-editor/xi-editor/issues) repo.
 
 Finally, before opening an issue, **use github's search bar** to make
@@ -86,23 +86,23 @@ reviews, see [code review process](#review-process).
 
 If you're looking for something to work on, a good first step is to browse
 the [issues](https://github.com/xi-editor/xi-editor/issues). Specifically,
-issues that are labeled 
+issues that are labeled
 [help wanted](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and/or
 [easy](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy)
 are good places to start. If you can't find anything there, feel free to ask
-on IRC, or play around with the editor and try to identify something that
+on Zulip, or play around with the editor and try to identify something that
 _you_ think is missing.
 
 ### Before you start work
 
 Before starting to work on an issue, consider the following:
-    
+
 - _Is it a bugfix or small change?_ If you notice a small bug somewhere,
  and you believe you have a fix, feel free to open a pull request directly.
 
 - _Is it a feature?_ If you have an idea for a new editor feature that is
  along the lines of something that already exists (for instance, adding a
- new command to reverse the letters in a selected region) _consider_ 
+ new command to reverse the letters in a selected region) _consider_
  opening a short issue beforehand, describing the feature you have in mind.
  Other contributors might be able to identify possible issues or
  refinements. This isn't _necessary_, but it might end up saving you work,
@@ -110,18 +110,18 @@ Before starting to work on an issue, consider the following:
  which feels good.
 
 - _Is it a major feature, affecting for instance the behaviour or appearance
- of a frontend, or the API or architecture of core?_ Before working on a 
+ of a frontend, or the API or architecture of core?_ Before working on a
  large change, please open a discussion/proposal issue. This should describe
- the problem you're trying to solve, and the approach you're considering; 
- think of this as a 'lite' version of Rust's 
- [RFC](https://github.com/rust-lang/rfcs) process. 
+ the problem you're trying to solve, and the approach you're considering;
+ think of this as a 'lite' version of Rust's
+ [RFC](https://github.com/rust-lang/rfcs) process.
 
 
 ### Before you open your PR
 
-Before pressing the 'Create pull request' button, 
+Before pressing the 'Create pull request' button,
 
-- _Run the tests_. It's easy to accidentally break something with even a small 
+- _Run the tests_. It's easy to accidentally break something with even a small
  change, so always run the tests locally before submitting (or updating) a PR.
  You can run all checks locally with the `xi-editor/rust/run_all_checks`. script.
 
@@ -132,18 +132,18 @@ Before pressing the 'Create pull request' button,
  If your change changes some behaviour, how might it be tested?
 
 - ***Be your own first reviewer***. On the page where you enter your message,
- you have a final opportunity to see your PR _as it will be seen by your 
+ you have a final opportunity to see your PR _as it will be seen by your
  reviewers_. This is a great opportunity to give it one last review, yourself.
- Imagine that it is someone else's work, that you're reviewing: what comments 
- would you have? If you spot a typo or a problem, you can push an update in 
+ Imagine that it is someone else's work, that you're reviewing: what comments
+ would you have? If you spot a typo or a problem, you can push an update in
  place, without losing your PR message or other state.
 
-- _Add yourself to the AUTHORS file_. If this is your first substantive pull 
+- _Add yourself to the AUTHORS file_. If this is your first substantive pull
 request in this repo, feel free to add yourself to the AUTHORS file.
 
 ### Review process
 
-Every non-trivial pull request goes through review. Everyone is welcome to 
+Every non-trivial pull request goes through review. Everyone is welcome to
 participate in review; review is an excellent time to ask questions about
 code or design decisions that you don't understand.
 
@@ -153,7 +153,7 @@ commit rights to the repo in question; larger changes (changes which add a
 feature, or significantly change behaviour or API) should also be approved by
 a maintainer.
 
-Before being merged, a change must pass 
+Before being merged, a change must pass
 [CI](https://en.wikipedia.org/wiki/Continuous_integration).
 
 #### Responsibilites of the approving reviewer
@@ -166,11 +166,11 @@ and overall coding style of the relevant repo
 - are ready and able to help resolve any problems that may be introduced by
 merging the change.
 
-If a PR is made by a contributor who has write access to the repo in question, 
-they are responsible for merging/rebasing the PR after it has been approved; 
+If a PR is made by a contributor who has write access to the repo in question,
+they are responsible for merging/rebasing the PR after it has been approved;
 otherwise it will be merged by the reviewer.
 
-If a patch adds or modifies behaviour that is observable in the client, 
+If a patch adds or modifies behaviour that is observable in the client,
 the reviewer should build the patch and verify that it works as expected.
 
 ### After submitting your change
@@ -186,7 +186,7 @@ type of feedback you might expect.
 _Patience_. As a general goal, we try to respond to all pull requests
 within a few days, and to do preliminary review within a week, but we
 don't always succeed. If you've opened a PR and haven't heard from
-anyone, feel free to comment on it, or stop by the IRC channel, to ask
+anyone, feel free to comment on it, or stop by Zulip, to ask
 if anyone has had a chance to take a look. It's very possible that it's
 been lost in the shuffle.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,14 +20,14 @@ follow the [Code of Conduct](https://github.com/xi-editor/xi-editor/blob/master/
 ## Getting started
 
 Not sure where to start? If you haven't already, take a look at the
-[docs](http://xi-editor.github.io/xi-editor/docs.html) to get a better
-sense of the project. Read through some issues and some open PRs, to
-get a sense for the habits of existing contributors. Drop by the #xi-editor
-stream on [Zulip](https://xi.zulipchat.com) (anyone with a Github account can
-easily signup) to follow ongoing discussions or ask questions. Clone the repos
-you're interested in, and make sure you can build and run the tests. If you
-can't, open an issue, and someone will try to help. Once you're up and running,
-there are a a number of ways to participate:
+[docs](http://xi-editor.github.io/xi-editor/docs.html) to get a better sense of
+the project. Read through some issues and some open PRs, to get a sense for the
+habits of existing contributors. Drop by the #xi-editor stream on
+[Zulip](https://xi.zulipchat.com) (anyone with a Github account can easily
+signup), or the #xi channel on irc.mozilla.org, to follow ongoing discussions or
+ask questions. Clone the repos you're interested in, and make sure you can build
+and run the tests. If you can't, open an issue, and someone will try to help.
+Once you're up and running, there are a a number of ways to participate:
 
 ### Opening issues
 
@@ -90,7 +90,7 @@ issues that are labeled
 [help wanted](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and/or
 [easy](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy)
 are good places to start. If you can't find anything there, feel free to ask
-on Zulip, or play around with the editor and try to identify something that
+on Zulip or IRC, or play around with the editor and try to identify something that
 _you_ think is missing.
 
 ### Before you start work

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ User settings are currently stored in files; the general preferences are
 located at `~/Library/Application Support/XiEditor/preferences.xiconfig`.
 This file can be opened from File > Preferences (⌘ + ,).
 
-The default font for XiEditor is 
+The default font for XiEditor is
 [Inconsolata](http://levien.com/type/myfonts/inconsolata.html), which
 is bundled with the app.
 
@@ -105,5 +105,5 @@ We gladly accept contributions via GitHub pull requests. Please see
 [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 If you are interested in contributing but not sure where to start, there is
-an active IRC channel at #xi on irc.mozilla.org. There is also a subreddit at
-[/r/xi_editor](https://www.reddit.com/r/xi_editor/).
+an active Zulip channel at #xi-editor on https://xi.zulipchat.com. There is also
+a subreddit at [/r/xi_editor](https://www.reddit.com/r/xi_editor/).

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ license.
 We gladly accept contributions via GitHub pull requests. Please see
 [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
-If you are interested in contributing but not sure where to start, there is
-an active Zulip channel at #xi-editor on https://xi.zulipchat.com. There is also
-a subreddit at [/r/xi_editor](https://www.reddit.com/r/xi_editor/).
+If you are interested in contributing but not sure where to start, there is an
+active Zulip channel at #xi-editor on https://xi.zulipchat.com. There is also
+a #xi channel on irc.mozilla.org. Finally, there is a subreddit at
+[/r/xi_editor](https://www.reddit.com/r/xi_editor/).

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -617,6 +617,7 @@
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -630,6 +631,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -643,6 +645,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XiEditor.app/Contents/MacOS/XiEditor";
 			};
@@ -657,6 +660,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XiEditor.app/Contents/MacOS/XiEditor";
 			};
@@ -670,6 +674,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditorUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = XiEditor;
 				USES_XCTRUNNER = YES;
@@ -684,6 +689,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditorUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = XiEditor;
 				USES_XCTRUNNER = YES;

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -617,7 +617,6 @@
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -631,7 +630,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -645,7 +643,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XiEditor.app/Contents/MacOS/XiEditor";
 			};
@@ -660,7 +657,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XiEditor.app/Contents/MacOS/XiEditor";
 			};
@@ -674,7 +670,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditorUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = XiEditor;
 				USES_XCTRUNNER = YES;
@@ -689,7 +684,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.levien.XiEditorUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = XiEditor;
 				USES_XCTRUNNER = YES;


### PR DESCRIPTION
This PR just updates the various project docs to point to Zulip instead of IRC. 

Resolves (for this repo): https://github.com/xi-editor/xi-editor/issues/961