### PR TITLE
Move `Events.StartPlugin` and `Events.StopPlugin` to `XiCore` protocol

### DIFF
--- a/Sources/XiEditor/Dispatcher.swift
+++ b/Sources/XiEditor/Dispatcher.swift
@@ -87,17 +87,6 @@ extension Event {
 typealias ViewIdentifier = String
 
 enum Events { // namespace
-    struct NewView: Event {
-        typealias Output = String
-
-        let path: String?
-        let method = "new_view"
-        var params: AnyObject? {
-            guard let path = self.path else { return [:] as AnyObject }
-            return ["file_path": path] as AnyObject
-        }
-        let dispatchMethod = EventDispatchMethod.sync
-    }
 
     struct InitialPlugins: Event {
         typealias Output = [String]

--- a/Sources/XiEditor/Dispatcher.swift
+++ b/Sources/XiEditor/Dispatcher.swift
@@ -99,18 +99,6 @@ enum Events { // namespace
         let dispatchMethod = EventDispatchMethod.sync
     }
 
-    struct StartPlugin: Event {
-        typealias Output = Void
-        let viewIdentifier: ViewIdentifier
-        let plugin: String
-
-        let method = "plugin"
-        var params: AnyObject? {
-            return ["command": "start", "view_id": viewIdentifier, "plugin_name": plugin] as AnyObject
-        }
-        let dispatchMethod = EventDispatchMethod.async
-    }
-
     struct StopPlugin: Event {
         typealias Output = Void
         let viewIdentifier: ViewIdentifier

--- a/Sources/XiEditor/Dispatcher.swift
+++ b/Sources/XiEditor/Dispatcher.swift
@@ -99,18 +99,6 @@ enum Events { // namespace
         let dispatchMethod = EventDispatchMethod.sync
     }
 
-    struct StopPlugin: Event {
-        typealias Output = Void
-        let viewIdentifier: ViewIdentifier
-        let plugin: String
-
-        let method = "plugin"
-        var params: AnyObject? {
-            return ["command": "stop", "view_id": viewIdentifier, "plugin_name": plugin] as AnyObject
-        }
-        let dispatchMethod = EventDispatchMethod.async
-    }
-
     struct InitialPlugins: Event {
         typealias Output = [String]
         let viewIdentifier: ViewIdentifier

--- a/Sources/XiEditor/Dispatcher.swift
+++ b/Sources/XiEditor/Dispatcher.swift
@@ -110,16 +110,6 @@ enum Events { // namespace
         }
         let dispatchMethod = EventDispatchMethod.async
     }
-    
-    struct TracingConfig: Event {
-        typealias Output = Void
-        let enabled: Bool
-        let method = "tracing_config"
-        var params: AnyObject? {
-            return ["enabled": enabled] as AnyObject
-        }
-        let dispatchMethod = EventDispatchMethod.async
-    }
 
     struct SaveTrace: Event {
         typealias Output = Void

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -721,9 +721,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         case .off:
             document.xiCore.start(plugin: pluginName, in: viewIdentifier)
         case .on:
-            Events.StopPlugin(
-                viewIdentifier: document.coreViewIdentifier!,
-                plugin: sender.title).dispatch(document.dispatcher)
+            document.xiCore.stop(plugin: pluginName, in: viewIdentifier)
         default:
             print("unexpected plugin menu state \(sender.title) \(sender.state)")
         }

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -715,10 +715,11 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     @objc func togglePlugin(_ sender: NSMenuItem) {
+        let pluginName = sender.title
+        let viewIdentifier = document.coreViewIdentifier!
         switch sender.state {
-        case .off: Events.StartPlugin(
-            viewIdentifier: document.coreViewIdentifier!,
-            plugin: sender.title).dispatch(document.dispatcher)
+        case .off:
+            document.xiCore.start(plugin: pluginName, in: viewIdentifier)
         case .on:
             Events.StopPlugin(
                 viewIdentifier: document.coreViewIdentifier!,

--- a/Sources/XiEditor/XiCore.swift
+++ b/Sources/XiEditor/XiCore.swift
@@ -30,6 +30,8 @@ protocol XiCore: class {
     func closeView(identifier: ViewIdentifier)
     /// Saves the buffer associated with `view_id` to `file_path`.
     func save(identifier: ViewIdentifier, filePath: String)
+    /// Starts the named plugin for the given view.
+    func start(plugin: String, in identifier: ViewIdentifier)
 }
 
 final class CoreConnection: XiCore {
@@ -70,6 +72,11 @@ final class CoreConnection: XiCore {
         let params = ["view_id": identifier,
                       "file_path": filePath]
         sendRpcAsync("save", params: params)
+    }
+
+    func start(plugin: String, in identifier: ViewIdentifier) {
+        let params = ["command": "start", "view_id": identifier, "plugin_name": plugin]
+        sendRpcAsync("plugin", params: params)
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Sources/XiEditor/XiCore.swift
+++ b/Sources/XiEditor/XiCore.swift
@@ -32,6 +32,8 @@ protocol XiCore: class {
     func save(identifier: ViewIdentifier, filePath: String)
     /// Starts the named plugin for the given view.
     func start(plugin: String, in identifier: ViewIdentifier)
+    /// Stops the named plugin for the given view.
+    func stop(plugin: String, in identifier: ViewIdentifier)
 }
 
 final class CoreConnection: XiCore {
@@ -76,6 +78,11 @@ final class CoreConnection: XiCore {
 
     func start(plugin: String, in identifier: ViewIdentifier) {
         let params = ["command": "start", "view_id": identifier, "plugin_name": plugin]
+        sendRpcAsync("plugin", params: params)
+    }
+
+    func stop(plugin: String, in identifier: ViewIdentifier) {
+        let params = ["command": "stop", "view_id": identifier, "plugin_name": plugin]
         sendRpcAsync("plugin", params: params)
     }
 

--- a/Tests/XiEditorTests/XiCoreTests.swift
+++ b/Tests/XiEditorTests/XiCoreTests.swift
@@ -85,6 +85,15 @@ class PluginRPCTests: XCTestCase {
         let expected = TestRPCCall(method: "plugin", params: params, callback: nil)
         XCTAssertEqual(expected, connection.calls.first)
     }
+
+    func testStopPlugin() {
+        let connection = TestConnection<String>()
+        let xiCore = CoreConnection(rpcSender: connection)
+        xiCore.stop(plugin: "plugout", in: "foo_id")
+        let params = ["command": "stop", "view_id": "foo_id", "plugin_name": "plugout"]
+        let expected = TestRPCCall(method: "plugin", params: params, callback: nil)
+        XCTAssertEqual(expected, connection.calls.first)
+    }
 }
 
 private func fakeCallback(result: RpcResult) {

--- a/Tests/XiEditorTests/XiCoreTests.swift
+++ b/Tests/XiEditorTests/XiCoreTests.swift
@@ -75,6 +75,18 @@ class CoreRPCTests: XCTestCase {
     }
 }
 
+class PluginRPCTests: XCTestCase {
+
+    func testStartPlugin() {
+        let connection = TestConnection<String>()
+        let xiCore = CoreConnection(rpcSender: connection)
+        xiCore.start(plugin: "plug", in: "foo_id")
+        let params = ["command": "start", "view_id": "foo_id", "plugin_name": "plug"]
+        let expected = TestRPCCall(method: "plugin", params: params, callback: nil)
+        XCTAssertEqual(expected, connection.calls.first)
+    }
+}
+
 private func fakeCallback(result: RpcResult) {
 }
 


### PR DESCRIPTION
This PR is another step on the way to #275
There are two little steps left, so we might be almost there 😄 

It also removes `Events.NewView` and `Events.TracingConfig` which are already implemented in `XiCore`.