### PR TITLE
Enable CI and Code Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,22 @@
 language: rust
-osx_image: xcode8.2
+osx_image: xcode9.2
 
-rust:
-  - stable
-  - nightly
+git:
+  submodules: true
 
 os:
-  - linux
   - osx
 
-matrix:
-  allow_failures:
-    - rust: nightly
+rust:
+  - 1.29.2
 
-cache:
-  directories:
-    - $HOME/.cargo
+cache: cargo
+
+before_script:
+  - sudo gem install xcpretty
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild; fi
-  - cd rust
-  - export CARGO_TARGET_DIR=/tmp/target
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then cargo build && cargo build --manifest-path syntect-plugin/Cargo.toml; fi
-  - for MANIFEST in Cargo.toml */Cargo.toml; do cargo test --manifest-path $MANIFEST; done
+  - xcodebuild clean test -scheme XiEditor | xcpretty -s
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.com/xi-editor/xi-mac.svg?branch=master)](https://travis-ci.com/xi-editor/xi-mac)
+[![codecov](https://codecov.io/gh/xi-editor/xi-editor/xi-mac/branch/master/graph/badge.svg)](https://codecov.io/gh/xi-editor/xi-mac)
+
 <h1 align="center">
   <a href="http://xi-editor.io/xi-editor"><img src="icons/xi-editor.png" alt="Xi Editor" width="256" height="256"/></a><br>
   <a href="http://xi-editor.io/xi-editor">Xi Editor</a>

--- a/XiEditor.xcodeproj/xcshareddata/xcschemes/XiEditor.xcscheme
+++ b/XiEditor.xcodeproj/xcshareddata/xcschemes/XiEditor.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -39,7 +40,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "AE499DE51C82BB2B002D68AF"


### PR DESCRIPTION
Addresses issue: [260](https://github.com/xi-editor/xi-mac/issues/260)

# CI

### UI Tests failing

- The first roadblock that I've encountered was that the UI teste were not passing:

```
 xcodebuild[2842:7421] Error Domain=IDETestOperationsObserverErrorDomain Code=8 "Unable to run UI Tests because Xcode Helper does not have permission to use Accessibility.
To enable UI testing, go to the Security & Privacy pane in System Preferences, select the Privacy tab, then select Accessibility, and add Xcode Helper to the list of applications allowed to use Accessibility"
```
(The full log can be found in [here](https://travis-ci.org/rakaramos/xi-mac/jobs/453325885))

When you run the tests for the first time, you see this nag:

The failing test just means that `Xcode Helper` doesn't have permission to use `Accessibility`

I noticed that we don't have any UI tests, so all I did was to disable them, at least for now.

Please note that, once we start adding UI tests, we'll need to fix it and maybe [this](https://github.com/univ-of-utah-marriott-library-apple/privacy_services_manager) is exactly what we need.

### `xcpretty`

- This is a very popular tool among Cocoa developers, because `xcodebuild` spits out way to many stuff. This tool just organize and format the output in a human readable fashion.
- Another point is that there's log limit size of [4 mb](https://github.com/travis-ci/docs-travis-ci-com/issues/281) on travis. This could became an issue when you put all the other dependency logs (installation) along side with `xcodebuild`.

# Code Coverage

- This has nothing to do with the [260](https://github.com/xi-editor/xi-mac/issues/260), but IMHO it's a nice thing to have [the badge] because one can check the amount of tests, without having to clone, build, run and test.




#### ⚠️ Both `travis` and `coverage` badges are pointing to my github account. If this ever goes in, we need to change that to the official repo!