### PR TITLE
Fixed status bar flash in new windows

### DIFF
--- a/Sources/XiEditor/StatusBar.swift
+++ b/Sources/XiEditor/StatusBar.swift
@@ -102,6 +102,7 @@ class StatusBar: NSView {
     override init(frame frameRect: NSRect) {
         super.init(frame: .zero)
         self.translatesAutoresizingMaskIntoConstraints = false
+        self.isHidden = true
         updateStatusBarVisibility()
     }
 


### PR DESCRIPTION
Previously, the status bar would be visible for a second on new window creation, even though it was empty.