### PR TITLE
Move set_language save_trace to XiCore

### DIFF
--- a/Sources/XiEditor/AppDelegate.swift
+++ b/Sources/XiEditor/AppDelegate.swift
@@ -524,7 +524,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
             // TODO: have UI start showing that the trace is saving & then clear
             // that in a callback (or make it synchronous on a global dispatch
             // queue).
-            Events.SaveTrace(destination: destination, frontendSamples: Trace.shared.snapshot()).dispatch(self.dispatcher!)
+            self.xiCore?.saveTrace(destination: destination, frontendSamples: Trace.shared.snapshot())
         }
     }
 

--- a/Sources/XiEditor/Dispatcher.swift
+++ b/Sources/XiEditor/Dispatcher.swift
@@ -98,18 +98,6 @@ enum Events { // namespace
         }
         let dispatchMethod = EventDispatchMethod.sync
     }
-    
-    struct SetLanguage: Event {
-        typealias Output = Void
-        let viewIdentifier: ViewIdentifier
-        let languageName: String
-        
-        let method = "set_language"
-        var params: AnyObject? {
-            return ["view_id": viewIdentifier, "language_id": languageName] as AnyObject
-        }
-        let dispatchMethod = EventDispatchMethod.async
-    }
 
     struct SaveTrace: Event {
         typealias Output = Void

--- a/Sources/XiEditor/Dispatcher.swift
+++ b/Sources/XiEditor/Dispatcher.swift
@@ -98,16 +98,4 @@ enum Events { // namespace
         }
         let dispatchMethod = EventDispatchMethod.sync
     }
-
-    struct SaveTrace: Event {
-        typealias Output = Void
-        let destination: String
-        let frontendSamples : [[String: AnyObject]]
-
-        let method = "save_trace"
-        var params: AnyObject? {
-            return ["destination": destination, "frontend_samples": frontendSamples] as AnyObject
-        }
-        let dispatchMethod = EventDispatchMethod.async
-    }
 }

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -685,13 +685,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     
     @IBAction func debugSetLanguage(_ sender: NSMenuItem) {
         guard sender.state != NSControl.StateValue.on else { print("language already active"); return }
-
-        let req = Events.SetLanguage(
-            viewIdentifier: document.coreViewIdentifier!,
-            languageName: sender.title
-        )
-
-        document.dispatcher.rpcSender.sendRpcAsync(req.method, params: req.params!)
+        document.xiCore.setLanguage(identifier: document.coreViewIdentifier!, languageName: sender.title)
     }
 
     @IBAction func debugPrintSpans(_ sender: AnyObject) {

--- a/Sources/XiEditor/XiCore.swift
+++ b/Sources/XiEditor/XiCore.swift
@@ -34,6 +34,9 @@ protocol XiCore: class {
     func start(plugin: String, in identifier: ViewIdentifier)
     /// Stops the named plugin for the given view.
     func stop(plugin: String, in identifier: ViewIdentifier)
+    /// Asks core to change the language of the buffer associated with the `view_id`.
+    /// If the change succeeds the client will receive a `language_changed` notification.
+    func setLanguage(identifier: ViewIdentifier, languageName: String)
 }
 
 final class CoreConnection: XiCore {
@@ -84,6 +87,11 @@ final class CoreConnection: XiCore {
     func stop(plugin: String, in identifier: ViewIdentifier) {
         let params = ["command": "stop", "view_id": identifier, "plugin_name": plugin]
         sendRpcAsync("plugin", params: params)
+    }
+
+    func setLanguage(identifier: ViewIdentifier, languageName: String) {
+        let params = ["view_id": identifier, "language_id": languageName]
+        sendRpcAsync("set_language", params: params)
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Sources/XiEditor/XiCore.swift
+++ b/Sources/XiEditor/XiCore.swift
@@ -37,6 +37,9 @@ protocol XiCore: class {
     /// Asks core to change the language of the buffer associated with the `view_id`.
     /// If the change succeeds the client will receive a `language_changed` notification.
     func setLanguage(identifier: ViewIdentifier, languageName: String)
+    /// Requests that core collect and write out traces to a file
+    /// at `destination`, including the samples from this frontend.
+    func saveTrace(destination: String, frontendSamples: [[String: AnyObject]])
 }
 
 final class CoreConnection: XiCore {
@@ -92,6 +95,11 @@ final class CoreConnection: XiCore {
     func setLanguage(identifier: ViewIdentifier, languageName: String) {
         let params = ["view_id": identifier, "language_id": languageName]
         sendRpcAsync("set_language", params: params)
+    }
+
+    func saveTrace(destination: String, frontendSamples: [[String: AnyObject]]) {
+        let params = ["destination": destination, "frontend_samples": frontendSamples] as AnyObject
+        sendRpcAsync("save_trace", params: params)
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Tests/XiEditorTests/XiCoreTests.swift
+++ b/Tests/XiEditorTests/XiCoreTests.swift
@@ -73,6 +73,14 @@ class CoreRPCTests: XCTestCase {
         let expected = TestRPCCall(method: "save", params: ["view_id": "foo", "file_path": "/foo/bar"], callback: nil)
         XCTAssertEqual(expected, connection.calls.first)
     }
+
+    func testSetLanguage() {
+        let connection = TestConnection<String>()
+        let xiCore = CoreConnection(rpcSender: connection)
+        xiCore.setLanguage(identifier: "foo", languageName: "C")
+        let expected = TestRPCCall(method: "set_language", params: ["view_id": "foo", "language_id": "C"], callback: nil)
+        XCTAssertEqual(expected, connection.calls.first)
+    }
 }
 
 class PluginRPCTests: XCTestCase {


### PR DESCRIPTION
This PR moves `set_language` and `save_trace` event calls to `XiCore`.

I will attempt to remove the `Dispatcher.swift` in the next PR.