### PR TITLE
Fix a crash at EditView _blinkInsertionPoint

### DIFF
--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -360,6 +360,8 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
 
     /// timer callback to toggle the blink state
     @objc func _blinkInsertionPoint() {
+        guard dataSource != nil else { return }
+        
         _cursorStateOn = !_cursorStateOn
         partialInvalidate(invalid: dataSource.lines.cursorInval)
     }

--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -122,7 +122,7 @@ func colorToArgb(_ color: NSColor) -> UInt32 {
     return (a << 24) | (r << 16) | (g << 8) | b
 }
 
-class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
+final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
     var scrollOrigin: NSPoint {
         didSet {
             if scrollOrigin != oldValue {


### PR DESCRIPTION
Addresses: #320 

As per @cmyr's [comment](https://github.com/xi-editor/xi-mac/issues/320?fbclid=IwAR3mv8CzVDgOB6Wsm4F__TBoNL0TpHKun64dm7ykAzDOevd-btJXBOqvko4#issuecomment-434113029), this should fix the issue.

### Pitch

Something caught my attention on this class, the `cursor blink` state is managed via `NSTimer` class (doing UI work), every 1 second.

IMHO, that should be done via [CVDisplayLink](https://developer.apple.com/documentation/corevideo/cvdisplaylink-k0k) because it's machinery allows us to run code on every frame refresh.

I would love to create a PR with these changes, but first I would like to run it by you guys.
Please note that I'm not an macOS expert, I do iOS for a living and when we have a situation like that, we avoid `NSTimer` in favour of `CADisplayLink`. Just porting some knowledge that _maybe_ makes sense on the macOS side.