### PR TITLE
Improve core log handling

### DIFF
--- a/Sources/XiEditor/LoggingUtilities.swift
+++ b/Sources/XiEditor/LoggingUtilities.swift
@@ -16,10 +16,10 @@ import Foundation
 
 
 /// Error tolerant wrapper for append-writing to a file.
-struct FileWriter {
+final class FileWriter {
     let path: URL
     let handle: FileHandle
-    
+
     init?(path: String) {
         let path = NSString(string: path).expandingTildeInPath
         if FileManager.default.fileExists(atPath: path) {
@@ -49,9 +49,10 @@ struct CircleBuffer<T> {
     public let capacity: Int
     /// The index of the most recently added item
     private var head: Int = 0
-    var storage = [T]()
-    
+    private var storage = [T]()
+
     init(capacity: Int) {
+        assert(capacity > 0, "CircleBuffer capacity should be >= 1")
         self.capacity = capacity
     }
 

--- a/Sources/XiEditor/LoggingUtilities.swift
+++ b/Sources/XiEditor/LoggingUtilities.swift
@@ -1,0 +1,79 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+
+/// Error tolerant wrapper for append-writing to a file.
+struct FileWriter {
+    let path: URL
+    let handle: FileHandle
+    
+    init?(path: String) {
+        let path = NSString(string: path).expandingTildeInPath
+        if FileManager.default.fileExists(atPath: path) {
+            print("file exists at \(path), will not overwrite")
+            return nil
+        }
+        self.path = URL(fileURLWithPath: path)
+        FileManager.default.createFile(atPath: self.path.path, contents: nil, attributes: nil)
+        
+        do {
+            try self.handle = FileHandle(forWritingTo: self.path)
+        } catch let err as NSError {
+            print("error opening log file \(err)")
+            return nil
+        }
+    }
+    
+    func write(bytes: Data) {
+        handle.write(bytes)
+    }
+}
+
+/// Fixed-size storage, discarding oldest items
+struct CircleBuffer<T> {
+    /// The maximum possible size for this buffer. The number of items
+    /// in the buffer may be less than this; space is allocated lazily.
+    public let capacity: Int
+    /// The index of the most recently added item
+    private var head: Int = 0
+    var storage = [T]()
+    
+    init(capacity: Int) {
+        self.capacity = capacity
+    }
+
+    var count: Int {
+        return storage.count
+    }
+
+    /// Pushes an item onto the end of the buffer, removing an item
+    /// from the front, if necessary.
+    mutating func push(_ item: T) {
+        if storage.count < capacity {
+            storage.append(item)
+        } else {
+            storage[head] = item
+            head = (head + 1) % capacity
+        }
+    }
+    
+    /// Returns a copy of the items in the buffer.
+    func allItems() -> [T] {
+        var result = Array(storage[head...])
+        result.append(contentsOf: storage[..<head])
+        return result
+    }
+}

--- a/Sources/XiEditor/RPCSending.swift
+++ b/Sources/XiEditor/RPCSending.swift
@@ -43,33 +43,6 @@ enum RpcResult {
 /// A completion handler for a synchronous RPC
 typealias RpcCallback = (RpcResult) -> ()
 
-/// Error tolerant wrapper for append-writing to a file.
-struct FileWriter {
-    let path: URL
-    let handle: FileHandle
-
-    init?(path: String) {
-        let path = NSString(string: path).expandingTildeInPath
-        if FileManager.default.fileExists(atPath: path) {
-            print("file exists at \(path), will not overwrite")
-            return nil
-        }
-        self.path = URL(fileURLWithPath: path)
-        FileManager.default.createFile(atPath: self.path.path, contents: nil, attributes: nil)
-
-        do {
-            try self.handle = FileHandle(forWritingTo: self.path)
-        } catch let err as NSError {
-            print("error opening log file \(err)")
-            return nil
-        }
-    }
-
-    func write(bytes: Data) {
-        handle.write(bytes)
-    }
-}
-
 /// Protocol describing the general interface with core.
 /// Concrete implementations may be provided for different transport mechanisms, e.g. stdin/stdout, unix sockets, or FFI.
 protocol RPCSending {

--- a/Tests/XiEditorTests/XiCoreTests.swift
+++ b/Tests/XiEditorTests/XiCoreTests.swift
@@ -112,6 +112,16 @@ class PluginRPCTests: XCTestCase {
     }
 }
 
+class LoggingTests: XCTestCase {
+    func testCircleBuffer() {
+        var buffer = CircleBuffer<Int>(capacity: 5);
+        for i in 0...8 {
+            buffer.push(i)
+        }
+        XCTAssertEqual(buffer.allItems(), [4, 5, 6, 7, 8])
+    }
+}
+
 private func fakeCallback(result: RpcResult) {
 }
 

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4DC153D32165202B000EB215 /* XiWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC153D22165202B000EB215 /* XiWindowController.swift */; };
 		4DCB4AF020576A6F00476F75 /* fonts in Resources */ = {isa = PBXBuildFile; fileRef = 4DCB4AEF20576A6E00476F75 /* fonts */; };
 		6038770720057B4500AABF17 /* XiDocumentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6038770620057B4500AABF17 /* XiDocumentController.swift */; };
+		6057C52521A07F1900F6BD47 /* LoggingUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6057C52421A07F1900F6BD47 /* LoggingUtilities.swift */; };
 		6083722F2058597B00E9CF5D /* ShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6083722E2058597B00E9CF5D /* ShadowView.swift */; };
 		6B0C298B2033C39500EA07AF /* XiWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0C298A2033C39500EA07AF /* XiWindow.swift */; };
 		6B0DCDD61E832101007C14A3 /* EditContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD51E832101007C14A3 /* EditContainerView.swift */; };
@@ -82,6 +83,7 @@
 		4DC153D22165202B000EB215 /* XiWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiWindowController.swift; sourceTree = "<group>"; };
 		4DCB4AEF20576A6E00476F75 /* fonts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fonts; sourceTree = "<group>"; };
 		6038770620057B4500AABF17 /* XiDocumentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiDocumentController.swift; sourceTree = "<group>"; };
+		6057C52421A07F1900F6BD47 /* LoggingUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingUtilities.swift; sourceTree = "<group>"; };
 		6083722E2058597B00E9CF5D /* ShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowView.swift; sourceTree = "<group>"; };
 		6B0C298A2033C39500EA07AF /* XiWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiWindow.swift; sourceTree = "<group>"; };
 		6B0DCDD51E832101007C14A3 /* EditContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditContainerView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -215,6 +217,7 @@
 				AE168C5B1E4AD87B008249AE /* LineCache.swift */,
 				AE0243F51E4BDF8A00641BDA /* StyleMap.swift */,
 				AEC4F6B21FF5AF130060E10E /* UnfairLock.swift */,
+				6057C52421A07F1900F6BD47 /* LoggingUtilities.swift */,
 				AEC4F6C91FFB02F10060E10E /* Trace.swift */,
 				6B90DD1B1F129C1A00DF3CE2 /* PluginCommand.swift */,
 				6B53F5F11EF963EB00A4C664 /* Theme.swift */,
@@ -465,6 +468,7 @@
 				6B0C298B2033C39500EA07AF /* XiWindow.swift in Sources */,
 				6038770720057B4500AABF17 /* XiDocumentController.swift in Sources */,
 				6B90DD221F14110B00DF3CE2 /* UserInputPromptController.swift in Sources */,
+				6057C52521A07F1900F6BD47 /* LoggingUtilities.swift in Sources */,
 				832910D920229C2D0042C32B /* Fps.swift in Sources */,
 				AED22D781FE8404D0096E7C3 /* Renderer.swift in Sources */,
 				6BA1873B1FDDD7B6008220DA /* XiClipView.swift in Sources */,

--- a/XiEditor.xcodeproj/xcshareddata/xcschemes/XiEditor.xcscheme
+++ b/XiEditor.xcodeproj/xcshareddata/xcschemes/XiEditor.xcscheme
@@ -82,6 +82,18 @@
             ReferencedContainer = "container:XiEditor.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "XI_LOG"
+            value = "DEBUG"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "RUST_BACKTRACE"
+            value = "FULL"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
This adds a few things:

- it passes our logging directory to core as a launch argument (closes #298)
- it keeps the last 100 lines of core's stderr around, and dumps this to a file if core exits unexpectedly

It still doesn't feel like we handle the core connection very elegantly. It would be nice, for instance, if we showed an alert if core had crashed, maybe with an option to open the log directory. It would also be nice if we were better about how we managed the subprocess's shutdown, in general? We crash pretty hard currently.