### PR TITLE
Fix alignment of find buttons and search field

### DIFF
--- a/Sources/XiEditor/Main.storyboard
+++ b/Sources/XiEditor/Main.storyboard
@@ -280,7 +280,7 @@ Gw
                                                 <subviews>
                                                     <segmentedControl verticalHuggingPriority="750" ambiguous="YES" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="neW-QX-zJG">
                                                         <rect key="frame" x="-1" y="1" width="208" height="20"/>
-                                                        <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="bsz-je-mdh">
+                                                        <segmentedCell key="cell" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="roundRect" trackingMode="momentary" id="bsz-je-mdh">
                                                             <font key="font" metaFont="cellTitle"/>
                                                             <segments>
                                                                 <segment label="Replace" imageScaling="none"/>
@@ -436,6 +436,7 @@ Gw
                     </customView>
                     <connections>
                         <outlet property="addButton" destination="WtA-NA-zjT" id="sBs-ZU-83X"/>
+                        <outlet property="buttonContainer" destination="YGp-T4-eoX" id="59z-5h-5WQ"/>
                         <outlet property="deleteButton" destination="V7s-ei-piI" id="cWW-x6-p20"/>
                         <outlet property="searchField" destination="4N3-Md-ylI" id="EXI-Ta-lqU"/>
                     </connections>

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -184,6 +184,7 @@ class SuplementaryFindViewController: NSViewController, NSSearchFieldDelegate, N
     @IBOutlet weak var searchField: NSSearchField!
     @IBOutlet weak var addButton: NSButton!
     @IBOutlet weak var deleteButton: NSButton!
+    @IBOutlet weak var buttonContainer: NSStackView!
 
     let resultCountLabel = Label(title: "")
 
@@ -247,8 +248,7 @@ class SuplementaryFindViewController: NSViewController, NSSearchFieldDelegate, N
     }
 
     func showButtons(show: Bool) {
-        addButton.isHidden = !show
-        deleteButton.isHidden = !show
+        buttonContainer.isHidden = !show
     }
 
     func disableAddButton(disable: Bool) {


### PR DESCRIPTION
This fixes some alignment issues in the search bar. Before the search field was not correctly aligned with the replace field. Also the replace buttons were not correctly aligned. Now it looks like this:

<img width="580" alt="screenshot 2018-11-22 at 19 03 10" src="https://user-images.githubusercontent.com/1239705/48927300-a589c580-ee89-11e8-9bd6-438a7ea1a39a.png">
