### PR TITLE
Fixed bug in calculating the replacement range

### DIFF
--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -274,7 +274,7 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         var replacementRange = aRange
         var len = 0
         if let attrStr = aString as? NSAttributedString {
-            len = attrStr.string.count
+            len = attrStr.string.utf16.count
         } else if let str = aString as? NSString {
             len = str.length
         }


### PR DESCRIPTION
## Related Issues
`closes #366 `

## Summary
The redundant calls ,though inefficient, were done to provide visual feedback to the user while constructing text. The bug was in replaceCharactersInRange while calculating replacement range length.

Updated len to String.utf16.count as in the else case when aString is NSString.