### PR TITLE
Make predicate compatible with Xcode 9.2

### DIFF
--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -430,7 +430,9 @@ extension EditViewController {
 
         // remove finds that have been removed in core
         let activeFinds = status.map({$0["id"] as? Int})
-        let obsoleteFinds = findViewController.searchQueries.filter({!activeFinds.contains($0.id) && $0.id != nil})
+        // Note: the following can be simplified to .contains() when minimum SDK is Xcode 9.3
+        let obsoleteFinds = findViewController.searchQueries.filter({(find) -> Bool in
+            !activeFinds.contains(where: {$0 == find.id}) && find.id != nil})
         for query in obsoleteFinds {
             findViewController.removeSearchField(searchField: query)
         }


### PR DESCRIPTION
I'm still using Xcode 9.2, and #362 broke the build. This patch makes
it work again.

<!---
Welcome to the xi-mac front end of the xi-editor project! We're very excited for your contribution to become a part of the editor.
This template provides some basic instructions on how to format a pull request, so we can more easily understand it.
Anything within this commented block will not be a part of the visible text.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
