### PR TITLE
Improve json parsing for findStatus

### DIFF
--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -36,6 +36,7 @@ struct LineAssoc {
 
 /// Represents one search query
 struct FindQuery {
+    /// If we create a new query on the frontend it doesn't have an ID yet. The new query gets assigned an ID in core.
     let id: Int?
     let term: String?
     let caseSensitive: Bool

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -36,11 +36,11 @@ struct LineAssoc {
 
 /// Represents one search query
 struct FindQuery {
-    var id: Int?
-    var term: String?
-    var caseSensitive: Bool
-    var regex: Bool
-    var wholeWords: Bool
+    let id: Int?
+    let term: String?
+    let caseSensitive: Bool
+    let regex: Bool
+    let wholeWords: Bool
 
     func toJson() -> [String: Any] {
         var jsonQuery: [String: Any] = [

--- a/Sources/XiEditor/FindStatus.swift
+++ b/Sources/XiEditor/FindStatus.swift
@@ -1,0 +1,52 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+struct FindStatus {
+
+    init?(from json: [String: AnyObject]) {
+        guard let id = json["id"] as? Int,
+            let matches = json["matches"] as? Int,
+            let lines = json["lines"] as? [Int] else { return nil }
+        self.id = id
+        self.matches = matches
+        self.lines = lines
+        chars = json["chars"] as? String
+        caseSensitive = json["case_sensitive"] as? Bool
+        isRegex = json["is_regex"] as? Bool
+        wholeWords = json["whole_words"] as? Bool
+    }
+
+    /// Identifier for the current search query.
+    let id: Int
+
+    /// The current search query.
+    let chars: String?
+
+    /// Whether the active search is case matching.
+    let caseSensitive: Bool?
+
+    /// Whether the search query is considered as regular expression.
+    let isRegex: Bool?
+
+    /// Query only matches whole words.
+    let wholeWords: Bool?
+
+    /// Total number of matches.
+    let matches: Int
+
+    /// Line numbers which have find results.
+    let lines: [Int]
+}

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -388,15 +388,6 @@ extension EditViewController {
 
     func findStatus(status: [[String: AnyObject]]) {
         var findMarker: [Marker] = []
-
-        // status has the following expected format:
-        // [{
-        //      id: Int,
-        //      chars: String,
-        //      case_sensitive: Boolean,
-        //      whole_words: Boolean,
-        //      matches: Int
-        // }]
         let statusStructs = status.flatMap(FindStatus.init)
         for statusQuery in statusStructs {
             guard let firstStatus = statusStructs.first else { continue }

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -397,35 +397,32 @@ extension EditViewController {
         //      whole_words: Boolean,
         //      matches: Int
         // }]
-        for statusQuery in status {
-            guard let statusQueryId = statusQuery["id"] as? Int else { continue }
-            let query = queryController(in: findViewController, queryId: statusQueryId)
+        let statusStructs = status.flatMap(FindStatus.init)
+        for statusQuery in statusStructs {
+            guard let firstStatus = statusStructs.first else { continue }
 
-            if status.first?["chars"] != nil && !(status.first?["chars"] is NSNull) {
-                query?.searchField.stringValue = statusQuery["chars"] as! String
+            let query = queryController(in: findViewController, queryId: statusQuery.id)
+
+            if firstStatus.chars != nil {
+                query?.searchField.stringValue = statusQuery.chars!
             } else {
                 // clear count
                 (query?.searchField as? FindSearchField)?.resultCount = nil
             }
 
-            if status.first?["case_sensitive"] != nil && !(status.first?["case_sensitive"] is NSNull) {
-                query?.ignoreCase = !(statusQuery["case_sensitive"] != nil)
+            if firstStatus.caseSensitive != nil {
+                query?.ignoreCase = !(statusQuery.caseSensitive != nil)
             }
 
-            if status.first?["whole_words"] != nil && !(status.first?["whole_words"] is NSNull) {
-                query?.wholeWords = statusQuery["whole_words"] as! Bool
+            if firstStatus.wholeWords != nil {
+                query?.wholeWords = statusQuery.wholeWords!
             }
 
-            if let resultCount = statusQuery["matches"] as? Int {
-                (query?.searchField as? FindSearchField)?.resultCount = resultCount
-            }
+            (query?.searchField as? FindSearchField)?.resultCount = statusQuery.matches
 
-            if status.first?["lines"] != nil && !(status.first?["lines"] is NSNull) {
-                query?.lines = statusQuery["lines"] as! [Int]
-
-                for line in (query?.lines ?? []) {
-                    findMarker.append(Marker(line, color: NSColor.orange))
-                }
+            query?.lines = statusQuery.lines
+            statusQuery.lines.forEach {
+                findMarker.append(Marker($0, color: .orange))
             }
         }
 

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -398,18 +398,8 @@ extension EditViewController {
         //      matches: Int
         // }]
         for statusQuery in status {
-            var query = findViewController.searchQueries.first(where: { $0.id == statusQuery["id"] as? Int })
-
-            if query == nil {
-                if let newQuery = findViewController.searchQueries.first(where: { $0.id == nil }) {
-                    newQuery.id = statusQuery["id"] as? Int
-                    query = newQuery
-                } else {
-                    let searchField = findViewController.addSearchField(searchField: nil, becomeFirstResponder: false)
-                    searchField!.id = statusQuery["id"] as? String
-                    query = findViewController.searchQueries.first(where: { $0.id == statusQuery["id"] as? Int })
-                }
-            }
+            guard let statusQueryId = statusQuery["id"] as? Int else { continue }
+            let query = queryController(in: findViewController, queryId: statusQueryId)
 
             if status.first?["chars"] != nil && !(status.first?["chars"] is NSNull) {
                 query?.searchField.stringValue = statusQuery["chars"] as! String
@@ -449,6 +439,23 @@ extension EditViewController {
         }
 
         setMarker(findMarker)
+    }
+
+    private func queryController(in findViewController: FindViewController,
+                                 queryId: Int) -> SuplementaryFindViewController? {
+        var query = findViewController.searchQueries.first(where: { $0.id == queryId })
+
+        if query == nil {
+            if let newQuery = findViewController.searchQueries.first(where: { $0.id == nil }) {
+                newQuery.id = queryId
+                query = newQuery
+            } else {
+                let searchField = findViewController.addSearchField(searchField: nil, becomeFirstResponder: false)
+                searchField!.id = String(queryId)
+                query = findViewController.searchQueries.first(where: { $0.id == queryId })
+            }
+        }
+        return query
     }
 
     func setMarker(_ items: [Marker]) {

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -427,7 +427,7 @@ extension EditViewController {
         }
 
         // remove finds that have been removed in core
-        let activeFinds = status.map({$0["id"] as? Int})
+        let activeFinds = statusStructs.map { $0.id }
         // Note: the following can be simplified to .contains() when minimum SDK is Xcode 9.3
         let obsoleteFinds = findViewController.searchQueries.filter({(find) -> Bool in
             !activeFinds.contains(where: {$0 == find.id}) && find.id != nil})

--- a/Tests/XiEditorTests/FindStatusTests.swift
+++ b/Tests/XiEditorTests/FindStatusTests.swift
@@ -1,0 +1,107 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import XiEditor
+
+class FindStatusTests: XCTestCase {
+
+    func testParsingMinimalDict() {
+        let dict = [
+            "id": 1,
+            "chars": NSNull(),
+            "case_sensitive": NSNull(),
+            "is_regex": NSNull(),
+            "whole_words": NSNull(),
+            "matches": 64,
+            "lines": [10, 79, 85, 123, 134, 165],
+
+            ] as [String : AnyObject]
+
+        let status = FindStatus(from: dict)
+        XCTAssertNotNil(status)
+        XCTAssertEqual(1, status?.id)
+        XCTAssertNil(status?.chars)
+        XCTAssertNil(status?.caseSensitive)
+        XCTAssertNil(status?.isRegex)
+        XCTAssertNil(status?.wholeWords)
+        XCTAssertEqual(64, status?.matches)
+        XCTAssertEqual([10, 79, 85, 123, 134, 165], status?.lines)
+    }
+
+    func testParsingFullDict() {
+        let dict = [
+            "id": 1,
+            "chars": "a",
+            "case_sensitive": true,
+            "is_regex": true,
+            "whole_words": true,
+            "matches": 64,
+            "lines": [10, 79, 85, 123, 134, 165],
+
+            ] as [String : AnyObject]
+
+        let status = FindStatus(from: dict)
+        XCTAssertNotNil(status)
+        XCTAssertEqual(1, status?.id)
+        XCTAssertEqual("a", status?.chars)
+        XCTAssertEqual(true, status?.caseSensitive)
+        XCTAssertEqual(true, status?.isRegex)
+        XCTAssertEqual(true, status?.wholeWords)
+        XCTAssertEqual(64, status?.matches)
+        XCTAssertEqual([10, 79, 85, 123, 134, 165], status?.lines)
+    }
+
+    func testParsingDictWithoutId() {
+        let dict = [
+            "id": NSNull(),
+            "chars": NSNull(),
+            "case_sensitive": NSNull(),
+            "is_regex": NSNull(),
+            "whole_words": NSNull(),
+            "matches": 64,
+            "lines": [10, 79, 85, 123, 134, 165],
+
+            ] as [String : AnyObject]
+        XCTAssertNil(FindStatus(from: dict))
+    }
+
+    func testParsingDictWithoutMatchesCount() {
+        let dict = [
+            "id": 1,
+            "chars": NSNull(),
+            "case_sensitive": NSNull(),
+            "is_regex": NSNull(),
+            "whole_words": NSNull(),
+            "matches": NSNull(),
+            "lines": [10, 79, 85, 123, 134, 165],
+
+            ] as [String : AnyObject]
+        XCTAssertNil(FindStatus(from: dict))
+    }
+
+    func testParsingDictWithoutLines() {
+        let dict = [
+            "id": 1,
+            "chars": NSNull(),
+            "case_sensitive": NSNull(),
+            "is_regex": NSNull(),
+            "whole_words": NSNull(),
+            "matches": 64,
+            "lines": NSNull(),
+
+            ] as [String : AnyObject]
+        XCTAssertNil(FindStatus(from: dict))
+    }
+}

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		AED22D841FE84B4B0096E7C3 /* text.f.glsl in Resources */ = {isa = PBXBuildFile; fileRef = AED22D801FE84B4B0096E7C3 /* text.f.glsl */; };
 		AED22D861FE877000096E7C3 /* TextLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED22D851FE877000096E7C3 /* TextLine.swift */; };
 		AED23F181C83CBED002246CE /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED23F171C83CBEC002246CE /* EditView.swift */; };
+		D803A9A421C7C4630042DE8F /* FindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D803A9A321C7C4630042DE8F /* FindStatusTests.swift */; };
+		D803A9A621C7CCB90042DE8F /* FindStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D803A9A521C7CCB90042DE8F /* FindStatus.swift */; };
 		D810EA5221BB291D00EABB21 /* ClientImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810EA5121BB291D00EABB21 /* ClientImplementation.swift */; };
 		D8D319F0218CB39A00D108D4 /* XiCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D319EF218CB39A00D108D4 /* XiCore.swift */; };
 		D8D319F2218CBCD100D108D4 /* XiCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D319F1218CBCD100D108D4 /* XiCoreTests.swift */; };
@@ -175,6 +177,8 @@
 		AED22D801FE84B4B0096E7C3 /* text.f.glsl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = text.f.glsl; sourceTree = "<group>"; };
 		AED22D851FE877000096E7C3 /* TextLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLine.swift; sourceTree = "<group>"; };
 		AED23F171C83CBEC002246CE /* EditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditView.swift; sourceTree = "<group>"; };
+		D803A9A321C7C4630042DE8F /* FindStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindStatusTests.swift; sourceTree = "<group>"; };
+		D803A9A521C7CCB90042DE8F /* FindStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindStatus.swift; sourceTree = "<group>"; };
 		D810EA5121BB291D00EABB21 /* ClientImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientImplementation.swift; sourceTree = "<group>"; };
 		D8D319EF218CB39A00D108D4 /* XiCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiCore.swift; sourceTree = "<group>"; };
 		D8D319F1218CBCD100D108D4 /* XiCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiCoreTests.swift; sourceTree = "<group>"; };
@@ -340,6 +344,7 @@
 				6B53F5F11EF963EB00A4C664 /* Theme.swift */,
 				6B90DD211F14110B00DF3CE2 /* UserInputPromptController.swift */,
 				28F1ED491EC4C735008839BE /* Search.swift */,
+				D803A9A521C7CCB90042DE8F /* FindStatus.swift */,
 				E1288E7F20B06E9C0068EEB9 /* StatusBar.swift */,
 				832910D820229C2D0042C32B /* Fps.swift */,
 				E16BB89720FE42A600A0D7A1 /* HoverViewController.swift */,
@@ -357,6 +362,7 @@
 			children = (
 				D8D319F1218CBCD100D108D4 /* XiCoreTests.swift */,
 				AE499DDF1C82BB2B002D68AF /* XiEditorTests.swift */,
+				D803A9A321C7C4630042DE8F /* FindStatusTests.swift */,
 				AE499DE11C82BB2B002D68AF /* Info.plist */,
 			);
 			path = XiEditorTests;
@@ -687,6 +693,7 @@
 				28F1ED4A1EC4C735008839BE /* Search.swift in Sources */,
 				F5BDBF371DCA9D2C0042430B /* Document.swift in Sources */,
 				6B0C298B2033C39500EA07AF /* XiWindow.swift in Sources */,
+				D803A9A621C7CCB90042DE8F /* FindStatus.swift in Sources */,
 				6038770720057B4500AABF17 /* XiDocumentController.swift in Sources */,
 				6B90DD221F14110B00DF3CE2 /* UserInputPromptController.swift in Sources */,
 				6057C52521A07F1900F6BD47 /* LoggingUtilities.swift in Sources */,
@@ -703,6 +710,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE499DE01C82BB2B002D68AF /* XiEditorTests.swift in Sources */,
+				D803A9A421C7C4630042DE8F /* FindStatusTests.swift in Sources */,
 				D8D319F2218CBCD100D108D4 /* XiCoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Related to #378 

## Summary
This might be just a tip of the iceberg, but it seems like a good start.

There's one thing which is super unclear for me right now.

```swift
if firstStatus.caseSensitive != nil {
    query?.ignoreCase = !(statusQuery.caseSensitive != nil)
}
```

We first check the first item of the array if it has a value for `"case_sensitive"`, and then we get an other value under the same key from the actual index of the array.
Do we want to check the `status.first` for the presence of the value?

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-mac/master.