### PR TITLE
Make drawMarkers method in MarkerBar private

### DIFF
--- a/Sources/XiEditor/MarkerBar.swift
+++ b/Sources/XiEditor/MarkerBar.swift
@@ -67,7 +67,7 @@ class MarkerBar: NSScroller {
         drawMarkers()
     }
 
-    func drawMarkers() {
+    private func drawMarkers() {
         guard let markerBarHeight = layer?.bounds.height,
             let maxScrollerWidth = layer?.bounds.width,
             let totalLines = (markerDelegate as? EditViewController)?.lines.height,


### PR DESCRIPTION
## Summary
This is just a simple refactor where we encapsulate `drawMarkers()` in `MarkerBar` in order to make sure it won't get called outside of the scope of `MarkerBar`.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
