### PR TITLE
Unify & simplify some view geometry calculations

### DIFF
--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -26,6 +26,7 @@ protocol EditViewDataSource: class {
     var textMetrics: TextDrawingMetrics { get }
     var document: Document! { get }
     var gutterWidth: CGFloat { get }
+    var scrollOrigin: NSPoint { get }
     func maxWidthChanged(toWidth: Double)
 }
 
@@ -124,6 +125,10 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
     var theme: Theme {
         return styling.theme
+    }
+
+    var scrollOrigin: CGPoint {
+        return self.scrollView?.contentView.bounds.origin ?? CGPoint.zero
     }
 
     /// A mapping of available plugins to activation status.
@@ -298,18 +303,18 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         if infoPopover.isShown {
             infoPopover.performClose(self)
         }
-        editView.scrollOrigin = newOrigin
+
         shadowView.showLeftShadow = newOrigin.x > 0
         shadowView.showRightShadow = (editViewWidth.constant - (newOrigin.x + self.view.bounds.width)) > rightTextPadding
-        // TODO: this calculation doesn't take into account toppad; do in EditView in DRY fashion
-        let first = Int(floor(newOrigin.y / textMetrics.linespace))
-        let height = Int(ceil((scrollView.contentView.bounds.size.height) / textMetrics.linespace)) + 1
-        let last = first + height
 
+        let first = editView.yOffsetToLine(newOrigin.y)
+        let maxY = newOrigin.y + scrollView.contentView.bounds.size.height
+        let last = editView.yOffsetToLine(maxY) + 1
         if first..<last != visibleLines {
             document.sendWillScroll(first: first, last: last)
             visibleLines = first..<last
         }
+        editView.needsDisplay = true
     }
 
     /// If we reuse an empty view when opening a file, we need to make sure we resend our size.

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -309,6 +309,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
         let first = editView.yOffsetToLine(newOrigin.y)
         let maxY = newOrigin.y + scrollView.contentView.bounds.size.height
+        // + 1 because this is an exclusive range
         let last = editView.yOffsetToLine(maxY) + 1
         if first..<last != visibleLines {
             document.sendWillScroll(first: first, last: last)

--- a/Sources/XiEditor/HoverViewController.swift
+++ b/Sources/XiEditor/HoverViewController.swift
@@ -123,7 +123,7 @@ extension EditViewController {
         if let event = hoverEvent {
             let hoverLine = editView.bufferPositionFromPoint(event.locationInWindow).line
             let symbolBaseline = editView.lineIxToBaseline(hoverLine)
-            let positioningPoint = NSPoint(x: event.locationInWindow.x, y: editView.frame.height + editView.scrollOrigin.y - symbolBaseline)
+            let positioningPoint = NSPoint(x: event.locationInWindow.x, y: editView.frame.height + scrollOrigin.y - symbolBaseline)
             let positioningSize = CGSize(width: 1, height: 1) // Generic size to center popover on cursor
 
             infoPopover.show(relativeTo: NSRect(origin: positioningPoint, size: positioningSize), of: self.view, preferredEdge: .minY)


### PR DESCRIPTION
This unifies the 'offset to line' calculations, and removes
the separate storage of a scroll offset in the EditView.

This tries to have  the y-offset to line number math in one place.
Additionally we don't track the scroll offset independently, and
assume that the view's bounds are up to date when we need them.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
