### PR TITLE
Add context menu on EditContainerView

### DIFF
--- a/Sources/XiEditor/EditContainerView.swift
+++ b/Sources/XiEditor/EditContainerView.swift
@@ -19,4 +19,10 @@ class EditContainerView: NSView {
     override var isFlipped: Bool {
         return true
     }
+    
+    override func menu(for event: NSEvent) -> NSMenu? {
+        return contextMenu
+    }
+    
+    public var contextMenu: NSMenu?
 }

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -183,6 +183,17 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         }
     }
 
+    // TODO: There should be a mechanism to validate the availability of a menu item's action.
+    var contextMenu: NSMenu = {
+        let menu = NSMenu()
+        
+        menu.addItem(withTitle: "Cut", action: #selector(cut(_:)), keyEquivalent: "")
+        menu.addItem(withTitle: "Copy", action: #selector(copy(_:)), keyEquivalent: "")
+        menu.addItem(withTitle: "Paste", action: #selector(paste(_:)), keyEquivalent: "")
+        
+        return menu
+    }()
+    
     var unifiedTitlebar = false {
         didSet {
             // Dont check if value is same as previous
@@ -232,6 +243,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         super.viewDidLoad()
         shadowView.wantsLayer = true
         editView.dataSource = self
+        editContainerView.contextMenu = contextMenu
         (scrollView.verticalScroller as! MarkerBar).markerDelegate = self
         scrollView.contentView.documentCursor = .iBeam
         scrollView.automaticallyAdjustsContentInsets = false


### PR DESCRIPTION
## Prelude

Wasn't aware moving to a branch for this work would close the original PR. For reference, it is PR #343 

## Summary
Implement a default context menu (for any event) on EditContainerView. The menu itself is generated in EditViewController so that it shares the same actions as other menu items and can be easily re-configured.

In addition, overriding menu(for:) in EditContainerView allows macOS to determine when/where to present the menu regardless of the user’s right click preferences.

Finally, having the menu on EditContaierView ensure it captures all possible events that could trigger a context menu because it is the top most view of the editor’s hierarchy.

### Implementation Notes
Right now, EditContainerView handles presenting the menu but in the future, when implementing a "word_select" on pop up for example, we might want to present the menu ourselves in EditViewController.

Also of note, we can look at querying core for figuring out what items should be available at a point. Eg copy should be disabled if there isn't a selection. 

Core can also decide when to select text when opening the menu (eg. "word_select" when nothing is selected, no selection if there is a selection). One concern is that I think this is a Mac specific behaviour so maybe querying core for something like "selection_exists" might work better.

<!---
Give reviewers and interested parties a good idea of how this is related to other issues or pull requests.
--->
## Related Issues
closes #306 

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.