### PR TITLE
Remove optionality from sendRpc RpcResult in Document.swift

### DIFF
--- a/Sources/XiEditor/Document.swift
+++ b/Sources/XiEditor/Document.swift
@@ -128,7 +128,7 @@ class Document: NSDocument {
 
     /// Note: this is a blocking call, and will also fail if the tab name hasn't been set yet.
     /// We should try to migrate users to either fully async or callback based approaches.
-    func sendRpc(_ method: String, params: Any) -> RpcResult? {
+    func sendRpc(_ method: String, params: Any) -> RpcResult {
         Trace.shared.trace(method, .rpc, .begin)
         let inner = ["method": method as AnyObject, "params": params, "view_id": coreViewIdentifier as AnyObject] as [String : Any]
         let result = xiCore.sendRpc("edit", params: inner)


### PR DESCRIPTION
## Summary
The signature of the result does not have to be an optional

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.