### PR TITLE
[Refactor] RPC Commands to `enum`

### DIFF
--- a/Sources/XiEditor/RPCSending.swift
+++ b/Sources/XiEditor/RPCSending.swift
@@ -287,7 +287,9 @@ class StdoutRPCSender: RPCSending {
                 return
         }
 
-        let viewIdentifier = params["view_id"] as? ViewIdentifier ?? ""
+        guard let viewIdentifier = params["view_id"] as? ViewIdentifier else {
+            fatalError("view_id missing")
+        }
         
         switch method {
         case .update:

--- a/Sources/XiEditor/RPCSending.swift
+++ b/Sources/XiEditor/RPCSending.swift
@@ -287,30 +287,28 @@ class StdoutRPCSender: RPCSending {
                 return
         }
 
-        guard let viewIdentifier = params["view_id"] as? ViewIdentifier else {
-            fatalError("view_id missing")
-        }
+        let viewIdentifier = params["view_id"] as? ViewIdentifier
         
         switch method {
         case .update:
             let update = params["update"] as! [String: AnyObject]
-            self.client?.update(viewIdentifier: viewIdentifier, update: update, rev: nil)
+            self.client?.update(viewIdentifier: viewIdentifier!, update: update, rev: nil)
 
         case .scrollTo:
             let line = params["line"] as! Int
             let col = params["col"] as! Int
-            self.client?.scroll(viewIdentifier: viewIdentifier, line: line, column: col)
+            self.client?.scroll(viewIdentifier: viewIdentifier!, line: line, column: col)
 
         case .defStyle:
             client?.defineStyle(style: params as! [String: AnyObject])
 
         case .pluginStarted:
             let plugin = params["plugin"] as! String
-            client?.pluginStarted(viewIdentifier: viewIdentifier, pluginName: plugin)
+            client?.pluginStarted(viewIdentifier: viewIdentifier!, pluginName: plugin)
 
         case .pluginStopped:
             let plugin = params["plugin"] as! String
-            client?.pluginStopped(viewIdentifier: viewIdentifier, pluginName: plugin)
+            client?.pluginStopped(viewIdentifier: viewIdentifier!, pluginName: plugin)
 
         case .availableThemes:
             let themes = params["themes"] as! [String]
@@ -325,13 +323,13 @@ class StdoutRPCSender: RPCSending {
         case .languageChanged:
             let languageIdentifier = params["language_id"] as! String
             client?.languageChanged(
-                viewIdentifier: viewIdentifier,
+                viewIdentifier: viewIdentifier!,
                 languageIdentifier: languageIdentifier
             )
             
         case .availablePlugins:
             let plugins = params["plugins"] as! [[String: AnyObject]]
-            client?.availablePlugins(viewIdentifier: viewIdentifier, plugins: plugins)
+            client?.availablePlugins(viewIdentifier: viewIdentifier!, plugins: plugins)
             
         case .availableLanguages:
             let languages = params["languages"] as! [String]
@@ -344,12 +342,12 @@ class StdoutRPCSender: RPCSending {
                 .filter { $0 != nil }
                 .map { $0! }
 
-            client?.updateCommands(viewIdentifier: viewIdentifier,
+            client?.updateCommands(viewIdentifier: viewIdentifier!,
                                    plugin: plugin, commands: cmds)
 
         case .configurationChanged:
             let changes = params["changes"] as! [String: AnyObject]
-            client?.configChanged(viewIdentifier: viewIdentifier, changes: changes)
+            client?.configChanged(viewIdentifier: viewIdentifier!, changes: changes)
 
         case .alert:
             let message = params["msg"] as! String
@@ -360,29 +358,29 @@ class StdoutRPCSender: RPCSending {
             let key = params["key"] as! String
             let value = params["value"] as! String
             let alignment = params["alignment"] as! String
-            client?.addStatusItem(viewIdentifier: viewIdentifier, source: source, key: key, value: value, alignment: alignment)
+            client?.addStatusItem(viewIdentifier: viewIdentifier!, source: source, key: key, value: value, alignment: alignment)
 
         case .updateStatusItem:
             let key = params["key"] as! String
             let value = params["value"] as! String
-            client?.updateStatusItem(viewIdentifier: viewIdentifier, key: key, value: value)
+            client?.updateStatusItem(viewIdentifier: viewIdentifier!, key: key, value: value)
 
         case .removeStatusItem:
             let key = params["key"] as! String
-            client?.removeStatusItem(viewIdentifier: viewIdentifier, key: key)
+            client?.removeStatusItem(viewIdentifier: viewIdentifier!, key: key)
 
         case .showHover:
             let requestIdentifier = params["request_id"] as! Int
             let result = params["result"] as! String
-            client?.showHover(viewIdentifier: viewIdentifier, requestIdentifier: requestIdentifier, result: result)
+            client?.showHover(viewIdentifier: viewIdentifier!, requestIdentifier: requestIdentifier, result: result)
 
         case .findStatus:
             let status = params["queries"] as! [[String: AnyObject]]
-            client?.findStatus(viewIdentifier: viewIdentifier, status: status)
+            client?.findStatus(viewIdentifier: viewIdentifier!, status: status)
 
         case .replaceStatus:
             let status = params["status"] as! [String: AnyObject]
-            client?.replaceStatus(viewIdentifier: viewIdentifier, status: status)
+            client?.replaceStatus(viewIdentifier: viewIdentifier!, status: status)
         }
     }
 

--- a/Sources/XiEditor/RPCSending.swift
+++ b/Sources/XiEditor/RPCSending.swift
@@ -273,7 +273,7 @@ class StdoutRPCSender: RPCSending {
                     assertionFailure("unexpected data from core: \(params)")
                     return
             }
-            
+
             sendResult(id: id, result: result)
         }
     }

--- a/Sources/XiEditor/RPCSending.swift
+++ b/Sources/XiEditor/RPCSending.swift
@@ -260,9 +260,7 @@ class StdoutRPCSender: RPCSending {
         guard let jsonMethod = json["method"] as? String,
               let params = json["params"],
               let id = json["id"],
-              let method = RPCRequestMethod(rawValue: jsonMethod),
-              let args = params as? [[String: AnyObject]],
-              let result = client?.measureWidth(args: args)
+              let method = RPCRequestMethod(rawValue: jsonMethod)
             else {
                 assertionFailure("unknown json from core: \(json)")
                 return
@@ -270,6 +268,12 @@ class StdoutRPCSender: RPCSending {
 
         switch method {
         case .measureWidth:
+            guard let args = params as? [[String: AnyObject]],
+                  let result = client?.measureWidth(args: args) else {
+                    assertionFailure("unexpected data from core: \(params)")
+                    return
+            }
+            
             sendResult(id: id, result: result)
         }
     }

--- a/Sources/XiEditor/RPCSending.swift
+++ b/Sources/XiEditor/RPCSending.swift
@@ -40,6 +40,41 @@ enum RpcResult {
     case ok(AnyObject)
 }
 
+enum RPCRequestMethod: String {
+    case measureWidth = "measure_width"
+}
+
+enum RPCNotificationMethod: String {
+    case alert
+    
+    case update
+    case updateCommands = "update_cmds"
+    
+    case addStatusItem = "add_status_item"
+    case updateStatusItem = "update_status_item"
+    case removeStatusItem = "remove_status_item"
+    
+    case configurationChanged = "config_changed"
+    
+    case scrollTo = "scroll_to"
+    case defStyle = "def_style"
+    
+    case availablePlugins = "available_plugins"
+    case pluginStarted = "plugin_started"
+    case pluginStopped = "plugin_stopped"
+    
+    case availableThemes = "available_themes"
+    case themeChanged = "theme_changed"
+    
+    case availableLanguages = "available_languages"
+    case languageChanged = "language_changed"
+    
+    case showHover = "show_hover"
+    
+    case findStatus = "find_status"
+    case replaceStatus = "replace_status"
+}
+
 /// A completion handler for a synchronous RPC
 typealias RpcCallback = (RpcResult) -> ()
 
@@ -222,126 +257,126 @@ class StdoutRPCSender: RPCSending {
     }
 
     private func handleRequest(json: [String: AnyObject]) {
-        guard let method = json["method"] as? String, let params = json["params"], let id = json["id"]
+        guard let jsonMethod = json["method"] as? String,
+              let params = json["params"],
+              let id = json["id"],
+              let method = RPCRequestMethod(rawValue: jsonMethod),
+              let args = params as? [[String: AnyObject]],
+              let result = client?.measureWidth(args: args)
             else {
-                print("unknown json from core: \(json)")
+                assertionFailure("unknown json from core: \(json)")
                 return
         }
 
         switch method {
-        case "measure_width":
-            let args = params as! [[String: AnyObject]]
-            if let result = self.client?.measureWidth(args: args) {
-                self.sendResult(id: id, result: result)
-            }
-        default:
-            print("unknown request \(method)")
+        case .measureWidth:
+            sendResult(id: id, result: result)
         }
     }
 
     private func handleNotification(json: [String: AnyObject]) {
-        guard let method = json["method"] as? String, let params = json["params"]
+        guard let jsonMethod = json["method"] as? String,
+              let params = json["params"],
+              let method = RPCNotificationMethod(rawValue: jsonMethod)
             else {
-                print("unknown json from core: \(json)")
+                assertionFailure("unknown json from core: \(json)")
                 return
         }
-        let viewIdentifier = params["view_id"] as? ViewIdentifier
 
+        let viewIdentifier = params["view_id"] as? ViewIdentifier ?? ""
+        
         switch method {
-        case "update":
+        case .update:
             let update = params["update"] as! [String: AnyObject]
-            self.client?.update(viewIdentifier: viewIdentifier!, update: update, rev: nil)
+            self.client?.update(viewIdentifier: viewIdentifier, update: update, rev: nil)
 
-        case "scroll_to":
+        case .scrollTo:
             let line = params["line"] as! Int
             let col = params["col"] as! Int
-            self.client?.scroll(viewIdentifier: viewIdentifier!, line: line, column: col)
+            self.client?.scroll(viewIdentifier: viewIdentifier, line: line, column: col)
 
-        case "def_style":
+        case .defStyle:
             client?.defineStyle(style: params as! [String: AnyObject])
 
-        case "plugin_started":
+        case .pluginStarted:
             let plugin = params["plugin"] as! String
-            client?.pluginStarted(viewIdentifier: viewIdentifier!, pluginName: plugin)
+            client?.pluginStarted(viewIdentifier: viewIdentifier, pluginName: plugin)
 
-        case "plugin_stopped":
+        case .pluginStopped:
             let plugin = params["plugin"] as! String
-            client?.pluginStopped(viewIdentifier: viewIdentifier!, pluginName: plugin)
+            client?.pluginStopped(viewIdentifier: viewIdentifier, pluginName: plugin)
 
-        case "available_themes":
+        case .availableThemes:
             let themes = params["themes"] as! [String]
             client?.availableThemes(themes: themes)
 
-        case "theme_changed":
+        case .themeChanged:
             let name = params["name"] as! String
             let themeJson = params["theme"] as! [String: AnyObject]
             let theme = Theme(jsonObject: themeJson)
             client?.themeChanged(name: name, theme: theme)
         
-        case "language_changed":
+        case .languageChanged:
             let languageIdentifier = params["language_id"] as! String
             client?.languageChanged(
-                viewIdentifier: viewIdentifier!,
+                viewIdentifier: viewIdentifier,
                 languageIdentifier: languageIdentifier
             )
             
-        case "available_plugins":
+        case .availablePlugins:
             let plugins = params["plugins"] as! [[String: AnyObject]]
-            client?.availablePlugins(viewIdentifier: viewIdentifier!, plugins: plugins)
+            client?.availablePlugins(viewIdentifier: viewIdentifier, plugins: plugins)
             
-        case "available_languages":
+        case .availableLanguages:
             let languages = params["languages"] as! [String]
             client?.availableLanguages(languages: languages)
 
-        case "update_cmds":
+        case .updateCommands:
             let plugin = params["plugin"] as! String
             let cmdsJson = params["cmds"] as! [[String: AnyObject]]
             let cmds = cmdsJson.map { Command(jsonObject: $0) }
                 .filter { $0 != nil }
                 .map { $0! }
 
-            client?.updateCommands(viewIdentifier: viewIdentifier!,
+            client?.updateCommands(viewIdentifier: viewIdentifier,
                                    plugin: plugin, commands: cmds)
 
-        case "config_changed":
+        case .configurationChanged:
             let changes = params["changes"] as! [String: AnyObject]
-            client?.configChanged(viewIdentifier: viewIdentifier!, changes: changes)
+            client?.configChanged(viewIdentifier: viewIdentifier, changes: changes)
 
-        case "alert":
+        case .alert:
             let message = params["msg"] as! String
             client?.alert(text: message)
 
-        case "add_status_item":
+        case .addStatusItem:
             let source = params["source"] as! String
             let key = params["key"] as! String
             let value = params["value"] as! String
             let alignment = params["alignment"] as! String
-            client?.addStatusItem(viewIdentifier: viewIdentifier!, source: source, key: key, value: value, alignment: alignment)
+            client?.addStatusItem(viewIdentifier: viewIdentifier, source: source, key: key, value: value, alignment: alignment)
 
-        case "update_status_item":
+        case .updateStatusItem:
             let key = params["key"] as! String
             let value = params["value"] as! String
-            client?.updateStatusItem(viewIdentifier: viewIdentifier!, key: key, value: value)
+            client?.updateStatusItem(viewIdentifier: viewIdentifier, key: key, value: value)
 
-        case "remove_status_item":
+        case .removeStatusItem:
             let key = params["key"] as! String
-            client?.removeStatusItem(viewIdentifier: viewIdentifier!, key: key)
+            client?.removeStatusItem(viewIdentifier: viewIdentifier, key: key)
 
-        case "show_hover":
+        case .showHover:
             let requestIdentifier = params["request_id"] as! Int
             let result = params["result"] as! String
-            client?.showHover(viewIdentifier: viewIdentifier!, requestIdentifier: requestIdentifier, result: result)
+            client?.showHover(viewIdentifier: viewIdentifier, requestIdentifier: requestIdentifier, result: result)
 
-        case "find_status":
+        case .findStatus:
             let status = params["queries"] as! [[String: AnyObject]]
-            client?.findStatus(viewIdentifier: viewIdentifier!, status: status)
+            client?.findStatus(viewIdentifier: viewIdentifier, status: status)
 
-        case "replace_status":
+        case .replaceStatus:
             let status = params["status"] as! [String: AnyObject]
-            client?.replaceStatus(viewIdentifier: viewIdentifier!, status: status)
-
-        default:
-            print("unknown notification \(method)")
+            client?.replaceStatus(viewIdentifier: viewIdentifier, status: status)
         }
     }
 


### PR DESCRIPTION
## Summary
- This is a tiny and simple PR where I just wrapped all the RPC request/notification commands into a enum, backed by a `String`.
- By using an `enum`, we avoid typos (also wave-away stringly typed interface) and leverage compiler checks (like when we add a new case, depending on the implementation, the compiler will error out, showing where we should handle this new case).
- Another change is to use `assertionFailure`, instead of `print-return`. `assertionFailure` runs only on debug mode and crashes the program (which, IMHO is the correct thing to do). So now, when something goes wrong, instead of checking Xcode's console, we'll have Xcode breaking it and giving us the full stracktrace.

## Review Checklist
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
