### PR TITLE
Issue #357 - Default Gutter Color to Theme's Background Color

### DIFF
--- a/Sources/XiEditor/Theme.swift
+++ b/Sources/XiEditor/Theme.swift
@@ -102,7 +102,7 @@ extension Theme {
             lineHighlight: line_highlight ?? defaults.lineHighlight,
             findHighlights: Theme.generateHighlightColors(findHighlight: find_highlight ?? defaults.findHighlights?.first!),
             findHighlightForeground: find_highlight_foreground ?? defaults.findHighlightForeground,
-            gutter: gutter ?? defaults.gutter,
+            gutter: gutter ?? (background ?? defaults.gutter),
             gutterForeground: gutter_foreground ?? defaults.gutterForeground,
             selection: selection ?? defaults.selection,
             selectionForeground: selection_foreground ?? defaults.selectionForeground,


### PR DESCRIPTION
## Summary
If a theme does not specify a gutter color, use the theme's background color as the gutter color.  This is changed from previously (which used the default gutter color).  If the theme also does not specify a background color, then simply fallback to the default gutter color as before.  This seems to give a better visual representation for themes overall that may not specify the gutter color.

## Related Issues
Related to #357 

closes #357 

## Details
When chaining Swift's [nil-coalescing operator](https://docs.swift.org/swift-book/LanguageGuide/BasicOperators.html#ID72) (??) it isn't strictly necessary to enclose the second statement in parenthesis.  However, I have done so for clarity.  For example, the following two examples will always produce the same result, though I feel like the first example is more clear in its intent.

`var something = something1 ?? (something2 ?? something3)`
`var something = something1 ?? something2 ?? something3`

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code (both manual and automated)
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
