### PR TITLE
Issue #388 - Ensure Gutter Line Number Highlight On Soft-Wrapped Lines

### DIFF
--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -562,8 +562,8 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
                 continue
             }
 
-            if let gutterNumber = line.number {
-                let gutterTL = gutterCache!.lookupLineNumber(lineIdx: gutterNumber, hasCursor: line.containsCursor)
+            if let gutterNumber = line.number, let gutterCache = gutterCache {
+                let gutterTL = gutterCache.lookupLineNumber(lineIdx: gutterNumber, hasCursor: line.containsCursor)
 
                 let x = dataSource.gutterWidth - (gutterXPad + CGFloat(gutterTL.width))
                 let y0 = yOff + dataSource.textMetrics.ascent + linespace * CGFloat(lineIx)
@@ -574,8 +574,9 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
                 previousY0 = y0
             } else {
                 // The case when the cursor is not at a logical line, but instead at a soft-wrapped line.
-                if line.containsCursor, let gutterNumber = previousGutterNumber, let x = previousX, let y0 = previousY0 {
-                    let gutterTL = gutterCache!.lookupLineNumber(lineIdx: gutterNumber, hasCursor: line.containsCursor)
+                if line.containsCursor, let gutterCache = gutterCache, let gutterNumber = previousGutterNumber,
+                    let x = previousX, let y0 = previousY0 {
+                    let gutterTL = gutterCache.lookupLineNumber(lineIdx: gutterNumber, hasCursor: line.containsCursor)
                     
                     // Redraw the gutter where the logical line starts.
                     // This ensures that the logcal line number is "highlighted" even when on a soft-wrapped line.

--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -549,6 +549,13 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         // is a bit of a hack, and some optimization might be possible with real clipping
         // (especially if the gutter background is the same as the theme background).
         renderer.drawSolidRect(x: 0, y: GLfloat(dirtyRect.origin.x), width: GLfloat(dataSource.gutterWidth), height: GLfloat(dirtyRect.height), argb: colorToArgb(dataSource.theme.gutter))
+        
+        // Store the most recent gutter drawing information.
+        // This is kept in the case that the line's gutter must be redraw because of soft-wrapping.
+        var previousGutterNumber: UInt?
+        var previousX: CGFloat?
+        var previousY0: CGFloat?
+        
         for lineIx in first..<last {
             let relLineIx = lineIx - first
             guard let line = lines[relLineIx] else {
@@ -561,6 +568,19 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
                 let x = dataSource.gutterWidth - (gutterXPad + CGFloat(gutterTL.width))
                 let y0 = yOff + dataSource.textMetrics.ascent + linespace * CGFloat(lineIx)
                 renderer.drawLine(line: gutterTL, x0: GLfloat(x), y0: GLfloat(y0))
+                
+                previousGutterNumber = gutterNumber
+                previousX = x
+                previousY0 = y0
+            } else {
+                // The case when the cursor is not at a logical line, but instead at a soft-wrapped line.
+                if line.containsCursor, let gutterNumber = previousGutterNumber, let x = previousX, let y0 = previousY0 {
+                    let gutterTL = gutterCache!.lookupLineNumber(lineIdx: gutterNumber, hasCursor: line.containsCursor)
+                    
+                    // Redraw the gutter where the logical line starts.
+                    // This ensures that the logcal line number is "highlighted" even when on a soft-wrapped line.
+                    renderer.drawLine(line: gutterTL, x0: GLfloat(x), y0: GLfloat(y0))
+                }
             }
         }
 

--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -557,7 +557,6 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         // is a bit of a hack, and some optimization might be possible with real clipping
         // (especially if the gutter background is the same as the theme background).
         renderer.drawSolidRect(x: 0, y: GLfloat(dirtyRect.origin.x), width: GLfloat(dataSource.gutterWidth), height: GLfloat(dirtyRect.height), argb: colorToArgb(dataSource.theme.gutter))
-        
         for lineIx in first..<last {
             let relLineIx = lineIx - first
             guard let line = lines[relLineIx] else {


### PR DESCRIPTION
## Summary
Ensure that when a cursor is on a soft-wrapped line the gutter line number is still "highlighted."  Previously, if a cursor was on a soft-wrapped line, the gutter line number for the logical line was not highlighted.

## Related Issues
Related to #388 

closes #388 

## Details
Previous behavior:
<img width="601" alt="issue 388_previous_behavior" src="https://user-images.githubusercontent.com/22179660/50504936-cb812780-0a3e-11e9-889b-8725fba465d3.png">
New behavior:
<img width="601" alt="issue 388_new_behavior" src="https://user-images.githubusercontent.com/22179660/50504945-d340cc00-0a3e-11e9-9536-091ab35e824f.png">

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [*] I have tested the code (both manual and automated)
- [ ] I have updated comments / documentation related to the changes I made.
- [*] I have rebased my PR branch onto xi-mac/master.