### PR TITLE
Remove unknown class from Main.storyboard

### DIFF
--- a/Sources/XiEditor/Main.storyboard
+++ b/Sources/XiEditor/Main.storyboard
@@ -41,7 +41,7 @@
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="x8W-KD-KOP" customClass="ShadowView" customModule="XiEditor" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                             </customView>
-                            <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qwv-ci-fVA" customClass="ScrollViewWithMarkerBar" customModule="XiEditor" customModuleProvider="target">
+                            <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qwv-ci-fVA">
                                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                                 <clipView key="contentView" wantsLayer="YES" drawsBackground="NO" id="1wJ-s5-kVO" customClass="XiClipView" customModule="XiEditor" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
@@ -60,7 +60,7 @@
                                         <constraint firstItem="rTT-RO-I3T" firstAttribute="top" secondItem="1wJ-s5-kVO" secondAttribute="top" id="BTR-DU-CLt"/>
                                     </constraints>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="hEG-a6-BYd" customClass="OpaqGridScroller" customModule="XiEditor" customModuleProvider="target">
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="hEG-a6-BYd">
                                     <rect key="frame" x="0.0" y="255" width="465" height="15"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>


### PR DESCRIPTION
## Summary
Remove `ScrollViewWithMarkerBar` and `OpaqGridScroller` from `Main.storyboard` because they are unnecessary and I found the logs.

<img width="1146" alt="2019-01-03 19 54 56" src="https://user-images.githubusercontent.com/11238461/50634482-290efa00-0f92-11e9-88bc-733d69ddaca5.png">

## Related Issues
nothing.

## Checklist
- [x] Searching for the code using these classes.
- [x] Build the application and tests.

## Review Checklist
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
