### PR TITLE
Move Recording commands to XiViewProxy protocol

### DIFF
--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -538,15 +538,15 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     @objc func toggleRecording(_ sender: Any?) {
-        document.sendRpcAsync("toggle_recording", params: ["recording_name": "DEFAULT"])
+        xiView.toggleRecording(name: "DEFAULT")
     }
 
     @objc func playRecording(_ sender: Any?) {
-        document.sendRpcAsync("play_recording", params: ["recording_name": "DEFAULT"])
+        xiView.playRecording(name: "DEFAULT")
     }
 
     @objc func clearRecording(_ sender: Any?) {
-        document.sendRpcAsync("clear_recording", params: ["recording_name": "DEFAULT"])
+        xiView.clearRecording(name: "DEFAULT")
     }
 
     @objc func paste(_ sender: AnyObject?) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -17,10 +17,12 @@ import Foundation
 
 protocol XiViewProxy: class {
     func resize(size: CGSize)
+
     func paste(characters: String)
     func copy() -> String?
     func cut() -> String?
-    
+
+    func toggleRecording(name: String)
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -64,6 +66,10 @@ final class XiViewConnection: XiViewProxy {
             print("\(method) failed: \(err)")
             return nil
         }
+    }
+
+    func toggleRecording(name: String) {
+        sendRpcAsync("toggle_recording", params: ["recording_name": name])
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -23,6 +23,7 @@ protocol XiViewProxy: class {
     func cut() -> String?
 
     func toggleRecording(name: String)
+    func playRecording(name: String)
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -70,6 +71,10 @@ final class XiViewConnection: XiViewProxy {
 
     func toggleRecording(name: String) {
         sendRpcAsync("toggle_recording", params: ["recording_name": name])
+    }
+
+    func playRecording(name: String) {
+        sendRpcAsync("play_recording", params: ["recording_name": name])
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -24,6 +24,7 @@ protocol XiViewProxy: class {
 
     func toggleRecording(name: String)
     func playRecording(name: String)
+    func clearRecording(name: String)
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -75,6 +76,10 @@ final class XiViewConnection: XiViewProxy {
 
     func playRecording(name: String) {
         sendRpcAsync("play_recording", params: ["recording_name": name])
+    }
+
+    func clearRecording(name: String) {
+        sendRpcAsync("clear_recording", params: ["recording_name": name])
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -79,4 +79,18 @@ class XiViewProxyTests: XCTestCase {
         XCTAssertEqual(result!, testCopyCharacters)
     }
 
+    func testToggleRecording() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params,_ in
+            XCTAssertEqual("toggle_recording", method)
+            let recordingParams = params as! [String: String]
+            XCTAssertEqual(["recording_name": "DEFAULT"], recordingParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let sync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: sync)
+        connection.toggleRecording(name: "DEFAULT")
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
 }

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -93,4 +93,18 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testPlayRecording() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params,_ in
+            XCTAssertEqual("play_recording", method)
+            let recordingParams = params as! [String: String]
+            XCTAssertEqual(["recording_name": "DEFAULT"], recordingParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let sync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: sync)
+        connection.playRecording(name: "DEFAULT")
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
 }

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -28,8 +28,7 @@ class XiViewProxyTests: XCTestCase {
             XCTAssertEqual(["width": 23 as CGFloat, "height": 42 as CGFloat], resizeParams)
             asyncCalledExpectation.fulfill()
         }
-        let sync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
-        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: sync)
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
         connection.resize(size: CGSize(width: 23, height: 42))
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
@@ -44,8 +43,7 @@ class XiViewProxyTests: XCTestCase {
             
             asyncCalledExpectation.fulfill()
         }
-        let sync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
-        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: sync)
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
         
         connection.paste(characters: testPasteCharacters)
         wait(for: [asyncCalledExpectation], timeout: 1)
@@ -87,8 +85,7 @@ class XiViewProxyTests: XCTestCase {
             XCTAssertEqual(["recording_name": "DEFAULT"], recordingParams)
             asyncCalledExpectation.fulfill()
         }
-        let sync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
-        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: sync)
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
         connection.toggleRecording(name: "DEFAULT")
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
@@ -101,8 +98,7 @@ class XiViewProxyTests: XCTestCase {
             XCTAssertEqual(["recording_name": "DEFAULT"], recordingParams)
             asyncCalledExpectation.fulfill()
         }
-        let sync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
-        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: sync)
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
         connection.playRecording(name: "DEFAULT")
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
@@ -115,10 +111,10 @@ class XiViewProxyTests: XCTestCase {
             XCTAssertEqual(["recording_name": "DEFAULT"], recordingParams)
             asyncCalledExpectation.fulfill()
         }
-        let sync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
-        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: sync)
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
         connection.clearRecording(name: "DEFAULT")
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    private let unusedSync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
 }

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -107,4 +107,18 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testClearRecording() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params,_ in
+            XCTAssertEqual("clear_recording", method)
+            let recordingParams = params as! [String: String]
+            XCTAssertEqual(["recording_name": "DEFAULT"], recordingParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let sync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: sync)
+        connection.clearRecording(name: "DEFAULT")
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
 }


### PR DESCRIPTION
## Summary
Move Recording commands to XiViewProxy protocol

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
