### PR TITLE
README.md: remove '-scheme "XiEditor"'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ is the front-end, and the back-end (or core) is now in
 **Build and Open:**
 
 ```bash
-> xcodebuild -scheme "XiEditor"
+> xcodebuild
 > open build/Release/XiEditor.app
 ```
 


### PR DESCRIPTION
## Summary

As discussed in Zulip, it seems that with that parameter, XiEditor.app
not actually ends up in the described place.