### PR TITLE
Fixed annotations update type casting

### DIFF
--- a/Sources/XiEditor/LineCache.swift
+++ b/Sources/XiEditor/LineCache.swift
@@ -109,7 +109,8 @@ fileprivate class LineCacheState<T>: UnfairLock {
     /// Updates the state by applying a delta. The update format is detailed in the
     /// [xi-core docs](http://xi-editor.github.io/xi-editor/docs/frontend-protocol.html#view-update-protocol).
     func applyUpdate(update: [String: AnyObject]) -> InvalSet {
-        annotations = AnnotationStore(from: (update["annotations"] as! [[String: AnyObject]]))
+        let updateAnnotations = update["annotations"] as? [[String: AnyObject]] ?? []
+        annotations = AnnotationStore(from: updateAnnotations)
 
         let inval = InvalSet()
         guard let ops = update["ops"] else { return inval }


### PR DESCRIPTION
## Summary
I have noticed that the RPC messages from xi-editor tend to be read with implicitly unwrapped optionals with `as!`. Then, it crashes when I build the latest xi-mac on `master` with a xi-editor submodule that was outdated.

As an example, I've made a change on the annotations dictionary to provide optional default value. Any reason why this is how the RPC messages is being casted to the appropriate types? 

## Related Issues
None so far.

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
