### PR TITLE
Move find_next to XiViewProxy

### DIFF
--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -368,11 +368,7 @@ extension EditViewController {
     }
 
     func findNext(wrapAround: Bool, allowSame: Bool) {
-        var params = ["wrap_around": wrapAround]
-        if allowSame {
-            params["allow_same"] = true
-        }
-        document.sendRpcAsync("find_next", params: params)
+        xiView.findNext(wrapAround: wrapAround, allowSame: allowSame, modifySelection: .set)
     }
 
     func findPrevious(wrapAround: Bool) {
@@ -478,12 +474,12 @@ extension EditViewController {
 
     @IBAction func addNextToSelection(_ sender: AnyObject?) {
         document.sendRpcAsync("selection_for_find", params: ["case_sensitive": false])
-        document.sendRpcAsync("find_next", params: ["wrap_around": false, "allow_same": true, "add_to_selection": false, "modify_selection": "add"])
+        xiView.findNext(wrapAround: false, allowSame: true, modifySelection: .add)
     }
 
     @IBAction func addNextToSelectionRemoveCurrent(_ sender: AnyObject?) {
         document.sendRpcAsync("selection_for_find", params: ["case_sensitive": false])
-        document.sendRpcAsync("find_next", params: ["wrap_around": true, "allow_same": true, "add_to_selection": true, "modify_selection": "add_removing_current"])
+        xiView.findNext(wrapAround: true, allowSame: true, modifySelection: .addRemovingCurrent)
     }
 
     @IBAction func selectionForReplace(_ sender: AnyObject?) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -14,6 +14,12 @@
 
 import Foundation
 
+enum SelectionModifier: String {
+    case none
+    case set
+    case add
+    case addRemovingCurrent = "add_removing_current"
+}
 
 protocol XiViewProxy: class {
     func resize(size: CGSize)
@@ -26,6 +32,8 @@ protocol XiViewProxy: class {
     func playRecording(name: String)
     func clearRecording(name: String)
 
+    /// Selects the next occurrence matching the search query.
+    func findNext(wrapAround: Bool, allowSame: Bool, modifySelection: SelectionModifier)
     /// Selects all occurrences matching the search query.
     func findAll()
     /// Shows/hides active search highlights.
@@ -85,6 +93,26 @@ final class XiViewConnection: XiViewProxy {
 
     func clearRecording(name: String) {
         sendRpcAsync("clear_recording", params: ["recording_name": name])
+    }
+
+    func findNext(wrapAround: Bool, allowSame: Bool, modifySelection: SelectionModifier) {
+        let params = createFindParamsFor(wrapAround: wrapAround, allowSame: allowSame, modifySelection: modifySelection)
+        sendRpcAsync("find_next", params: params)
+    }
+
+    /// All parameters are optional. Boolean parameters are by default `false` and `modify_selection` is `set` by default.
+    private func createFindParamsFor(wrapAround: Bool, allowSame: Bool, modifySelection: SelectionModifier) -> [String: Any] {
+        var params: [String: Any] = [:]
+        if wrapAround {
+            params["wrap_around"] = wrapAround
+        }
+        if allowSame {
+            params["allow_same"] = allowSame
+        }
+        if modifySelection != .set {
+            params["modify_selection"] = modifySelection.rawValue
+        }
+        return params
     }
 
     func findAll() {

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -129,6 +129,71 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testFindNextWrapAround() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_next", method)
+            let findParams = params as! [String: Bool]
+            XCTAssertEqual(["wrap_around": true], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findNext(wrapAround: true, allowSame: false, modifySelection: .set)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testFindNextAllowSame() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_next", method)
+            let findParams = params as! [String: Bool]
+            XCTAssertEqual(["allow_same": true], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findNext(wrapAround: false, allowSame: true, modifySelection: .set)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testFindNextModifySelectionNone() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_next", method)
+            let findParams = params as! [String: String]
+            XCTAssertEqual(["modify_selection": "none"], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findNext(wrapAround: false, allowSame: false, modifySelection: .none)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testFindNextModifySelectionAdd() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_next", method)
+            let findParams = params as! [String: String]
+            XCTAssertEqual(["modify_selection": "add"], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findNext(wrapAround: false, allowSame: false, modifySelection: .add)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testFindNextModifySelectionAddRemovingCurrent() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_next", method)
+            let findParams = params as! [String: String]
+            XCTAssertEqual(["modify_selection": "add_removing_current"], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findNext(wrapAround: false, allowSame: false, modifySelection: .addRemovingCurrent)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testFindAll() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params,_ in


### PR DESCRIPTION
## Summary
This is one of the possible approaches of moving `find_next` to `XiViewProxy`.

One thing which confused me during this implementation is the fact, that we're using `add_to_selection` flag as one of the `find_next` parameters. I digged a little into `xi-editor` codebase and I'm pretty sure it's not used there. Maybe @cmyr or @scholtzan could confirm that? 😄

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.