### PR TITLE
Move find_previous to XiViewProxy

### DIFF
--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -372,9 +372,7 @@ extension EditViewController {
     }
 
     func findPrevious(wrapAround: Bool) {
-        document.sendRpcAsync("find_previous", params: [
-            "wrap_around": wrapAround
-        ])
+        xiView.findPrevious(wrapAround: wrapAround, allowSame: false, modifySelection: .set)
     }
 
     func find(_ queries: [FindQuery]) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -32,6 +32,8 @@ protocol XiViewProxy: class {
     func playRecording(name: String)
     func clearRecording(name: String)
 
+    /// Selects the previous occurrence matching the search query.
+    func findPrevious(wrapAround: Bool, allowSame: Bool, modifySelection: SelectionModifier)
     /// Selects the next occurrence matching the search query.
     func findNext(wrapAround: Bool, allowSame: Bool, modifySelection: SelectionModifier)
     /// Selects all occurrences matching the search query.
@@ -93,6 +95,11 @@ final class XiViewConnection: XiViewProxy {
 
     func clearRecording(name: String) {
         sendRpcAsync("clear_recording", params: ["recording_name": name])
+    }
+
+    func findPrevious(wrapAround: Bool, allowSame: Bool, modifySelection: SelectionModifier) {
+        let params = createFindParamsFor(wrapAround: wrapAround, allowSame: allowSame, modifySelection: modifySelection)
+        sendRpcAsync("find_previous", params: params)
     }
 
     func findNext(wrapAround: Bool, allowSame: Bool, modifySelection: SelectionModifier) {

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -129,6 +129,71 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testFindPreviousWrapAround() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_previous", method)
+            let findParams = params as! [String: Bool]
+            XCTAssertEqual(["wrap_around": true], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findPrevious(wrapAround: true, allowSame: false, modifySelection: .set)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testFindPreviousAllowSame() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_previous", method)
+            let findParams = params as! [String: Bool]
+            XCTAssertEqual(["allow_same": true], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findPrevious(wrapAround: false, allowSame: true, modifySelection: .set)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testFindPreviousModifySelectionNone() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_previous", method)
+            let findParams = params as! [String: String]
+            XCTAssertEqual(["modify_selection": "none"], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findPrevious(wrapAround: false, allowSame: false, modifySelection: .none)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testFindPreviousModifySelectionAdd() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_previous", method)
+            let findParams = params as! [String: String]
+            XCTAssertEqual(["modify_selection": "add"], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findPrevious(wrapAround: false, allowSame: false, modifySelection: .add)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testFindPreviousModifySelectionAddRemovingCurrent() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("find_previous", method)
+            let findParams = params as! [String: String]
+            XCTAssertEqual(["modify_selection": "add_removing_current"], findParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.findPrevious(wrapAround: false, allowSame: false, modifySelection: .addRemovingCurrent)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testFindNextWrapAround() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params, _ in


### PR DESCRIPTION
## Summary
Let's move `find_previous` to `XiViewProxy`.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.