### PR TITLE
Move selection_for_find and selection_for_replace to XiViewProxy

### DIFF
--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -470,12 +470,12 @@ extension EditViewController {
     }
 
     @IBAction func addNextToSelection(_ sender: AnyObject?) {
-        document.sendRpcAsync("selection_for_find", params: ["case_sensitive": false])
+        xiView.selectionForFind(caseSensitive: false)
         xiView.findNext(wrapAround: false, allowSame: true, modifySelection: .add)
     }
 
     @IBAction func addNextToSelectionRemoveCurrent(_ sender: AnyObject?) {
-        document.sendRpcAsync("selection_for_find", params: ["case_sensitive": false])
+        xiView.selectionForFind(caseSensitive: false)
         xiView.findNext(wrapAround: true, allowSame: true, modifySelection: .addRemovingCurrent)
     }
 
@@ -533,7 +533,7 @@ extension EditViewController {
             replaceNext()
 
         case .setSearchString:
-            document.sendRpcAsync("selection_for_find", params: ["case_sensitive": false])
+            xiView.selectionForFind(caseSensitive: false)
 
         case .replaceAllInSelection:
             Swift.print("replaceAllInSelection not implemented")

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -480,7 +480,7 @@ extension EditViewController {
     }
 
     @IBAction func selectionForReplace(_ sender: AnyObject?) {
-        document.sendRpcAsync("selection_for_replace", params: [])
+        xiView.selectionForReplace(caseSensitive: false)
     }
 
     @IBAction func multipleSearchQueries(_ sender: AnyObject?) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -142,22 +142,23 @@ final class XiViewConnection: XiViewProxy {
         sendRpcAsync("highlight_find", params: ["visible": visible])
     }
 
-    /// The parameter `case_sensitive` is optional and `false` if not set.
     func selectionForFind(caseSensitive: Bool) {
-        var params: [String: Bool] = [:]
-        if caseSensitive {
-            params["case_sensitive"] = caseSensitive
-        }
+        let params = createSelectionParamsFor(caseSensitive: caseSensitive)
         sendRpcAsync("selection_for_find", params: params)
     }
 
-    /// The parameter `case_sensitive` is optional and `false` if not set.
     func selectionForReplace(caseSensitive: Bool) {
-        var params: [String: Bool] = [:]
-        if caseSensitive {
-            params["case_sensitive"] = caseSensitive
-        }
+        let params = createSelectionParamsFor(caseSensitive: caseSensitive)
         sendRpcAsync("selection_for_replace", params: params)
+    }
+
+    /// The parameter `case_sensitive` is optional and `false` if not set.
+    private func createSelectionParamsFor(caseSensitive: Bool) -> [String: Bool] {
+        if caseSensitive {
+            return ["case_sensitive": caseSensitive]
+        } else {
+            return [:]
+        }
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -151,7 +151,6 @@ final class XiViewConnection: XiViewProxy {
         sendRpcAsync("selection_for_find", params: params)
     }
 
-
     /// The parameter `case_sensitive` is optional and `false` if not set.
     func selectionForReplace(caseSensitive: Bool) {
         var params: [String: Bool] = [:]

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -45,6 +45,8 @@ protocol XiViewProxy: class {
 
     /// Sets the current selection as the search query.
     func selectionForFind(caseSensitive: Bool)
+    /// Sets the current selection as the replacement string.
+    func selectionForReplace(caseSensitive: Bool)
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -147,6 +149,16 @@ final class XiViewConnection: XiViewProxy {
             params["case_sensitive"] = caseSensitive
         }
         sendRpcAsync("selection_for_find", params: params)
+    }
+
+
+    /// The parameter `case_sensitive` is optional and `false` if not set.
+    func selectionForReplace(caseSensitive: Bool) {
+        var params: [String: Bool] = [:]
+        if caseSensitive {
+            params["case_sensitive"] = caseSensitive
+        }
+        sendRpcAsync("selection_for_replace", params: params)
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -42,6 +42,9 @@ protocol XiViewProxy: class {
     func findAll()
     /// Shows/hides active search highlights.
     func highlightFind(visible: Bool)
+
+    /// Sets the current selection as the search query.
+    func selectionForFind(caseSensitive: Bool)
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -135,6 +138,15 @@ final class XiViewConnection: XiViewProxy {
 
     func highlightFind(visible: Bool) {
         sendRpcAsync("highlight_find", params: ["visible": visible])
+    }
+
+    /// The parameter `case_sensitive` is optional and `false` if not set.
+    func selectionForFind(caseSensitive: Bool) {
+        var params: [String: Bool] = [:]
+        if caseSensitive {
+            params["case_sensitive"] = caseSensitive
+        }
+        sendRpcAsync("selection_for_find", params: params)
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -129,6 +129,32 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testSelectionForFindTrue() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("selection_for_find", method)
+            let selectionParams = params as! [String: Bool]
+            XCTAssertEqual(["case_sensitive": true], selectionParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.selectionForFind(caseSensitive: true)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testSelectionForFindFalse() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("selection_for_find", method)
+            let selectionParams = params as! [String: Bool]
+            XCTAssertEqual([:], selectionParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.selectionForFind(caseSensitive: false)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testFindPreviousWrapAround() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params, _ in

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -155,6 +155,32 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testSelectionForReplaceTrue() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("selection_for_replace", method)
+            let selectionParams = params as! [String: Bool]
+            XCTAssertEqual(["case_sensitive": true], selectionParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.selectionForReplace(caseSensitive: true)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
+    func testSelectionForReplaceFalse() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("selection_for_replace", method)
+            let selectionParams = params as! [String: Bool]
+            XCTAssertEqual([:], selectionParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.selectionForReplace(caseSensitive: false)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testFindPreviousWrapAround() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params, _ in


### PR DESCRIPTION
## Summary
This PR moves `selection_for_find` and `selection_for_replace` to XiViewProxy.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.