### PR TITLE
Replace the replace methods from XiViewProtocol

### DIFF
--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -448,7 +448,7 @@ extension EditViewController {
     }
 
     func replaceAll() {
-        document.sendRpcAsync("replace_all", params: [])
+        xiView.replaceAll()
     }
 
     func replaceStatus(status: [String: AnyObject]) {

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -444,7 +444,7 @@ extension EditViewController {
     }
 
     func replaceNext() {
-        document.sendRpcAsync("replace_next", params: [])
+        xiView.replaceNext()
     }
 
     func replaceAll() {

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -460,8 +460,7 @@ extension EditViewController {
     }
 
     func replace(_ term: String) {
-        let params: [String: Any] = ["chars": term]
-        document.sendRpcAsync("replace", params: params)
+        xiView.replace(chars: term)
     }
 
     @IBAction func addNextToSelection(_ sender: AnyObject?) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -43,6 +43,9 @@ protocol XiViewProxy: class {
     /// Shows/hides active search highlights.
     func highlightFind(visible: Bool)
 
+    /// Sets the replacement string.
+    func replace(chars: String)
+
     /// Sets the current selection as the search query.
     func selectionForFind(caseSensitive: Bool)
     /// Sets the current selection as the replacement string.
@@ -140,6 +143,10 @@ final class XiViewConnection: XiViewProxy {
 
     func highlightFind(visible: Bool) {
         sendRpcAsync("highlight_find", params: ["visible": visible])
+    }
+
+    func replace(chars: String) {
+        sendRpcAsync("replace", params: ["chars": chars])
     }
 
     func selectionForFind(caseSensitive: Bool) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -47,6 +47,8 @@ protocol XiViewProxy: class {
     func replace(chars: String)
     /// Replaces the next matching occurrence with the replacement string.
     func replaceNext()
+    /// Replaces all matching occurrences with the replacement string.
+    func replaceAll()
 
     /// Sets the current selection as the search query.
     func selectionForFind(caseSensitive: Bool)
@@ -153,6 +155,10 @@ final class XiViewConnection: XiViewProxy {
 
     func replaceNext() {
         sendRpcAsync("replace_next", params: [])
+    }
+
+    func replaceAll() {
+        sendRpcAsync("replace_all", params: [])
     }
 
     func selectionForFind(caseSensitive: Bool) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -45,6 +45,8 @@ protocol XiViewProxy: class {
 
     /// Sets the replacement string.
     func replace(chars: String)
+    /// Replaces the next matching occurrence with the replacement string.
+    func replaceNext()
 
     /// Sets the current selection as the search query.
     func selectionForFind(caseSensitive: Bool)
@@ -147,6 +149,10 @@ final class XiViewConnection: XiViewProxy {
 
     func replace(chars: String) {
         sendRpcAsync("replace", params: ["chars": chars])
+    }
+
+    func replaceNext() {
+        sendRpcAsync("replace_next", params: [])
     }
 
     func selectionForFind(caseSensitive: Bool) {

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -155,6 +155,19 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testReplaceAll() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("replace_all", method)
+            let replaceParams = params as! [String]
+            XCTAssertEqual([], replaceParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.replaceAll()
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testSelectionForFindTrue() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params, _ in

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -142,6 +142,19 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testReplaceNext() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("replace_next", method)
+            let replaceParams = params as! [String]
+            XCTAssertEqual([], replaceParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.replaceNext()
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testSelectionForFindTrue() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params, _ in

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -129,6 +129,19 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testReplace() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("replace", method)
+            let replaceParams = params as! [String: String]
+            XCTAssertEqual(["chars": "replacement"], replaceParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.replace(chars: "replacement")
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testSelectionForFindTrue() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params, _ in


### PR DESCRIPTION
## Summary
In this PR we replace the replace methods with the ones from XiViewProtocol.

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
