### PR TITLE
Remove the optionality from the replace method in FindDelegate protocol

### DIFF
--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -66,7 +66,7 @@ protocol FindDelegate: class {
     func closeFind()
     func findStatus(status: [[String: AnyObject]])
     func replaceStatus(status: [String: AnyObject])
-    func replace(_ term: String?)
+    func replace(_ term: String)
     func replaceNext()
     func replaceAll()
     func updateScrollPosition(previousOffset: CGFloat)

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -459,13 +459,8 @@ extension EditViewController {
         // todo: preserve case
     }
 
-    func replace(_ term: String?) {
-        var params: [String: Any] = [:]
-
-        if term != nil {
-            params["chars"] = term
-        }
-
+    func replace(_ term: String) {
+        let params: [String: Any] = ["chars": term]
         document.sendRpcAsync("replace", params: params)
     }
 


### PR DESCRIPTION
## Summary
The optional parameter was removed because it doesn't seem to be used anywhere. If this is wrong - please let me know 😄


## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.