### PR TITLE
Use XiViewProxy for delete_backward and insert RPC calls

### DIFF
--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -102,7 +102,7 @@ struct GutterCache {
 typealias BufferPosition = (line: Int, column: Int)
 
 
-func insertedStringToJson(_ stringToInsert: NSString) -> Any {
+func insertedStringToJson(_ stringToInsert: String) -> Any {
     return ["chars": stringToInsert]
 }
 
@@ -298,8 +298,8 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
             dataSource.document.sendRpcAsync("delete_backward", params  : [])
         }
         if let attrStr = aString as? NSAttributedString {
-            dataSource.document.sendRpcAsync("insert", params: insertedStringToJson(attrStr.string as NSString))
-        } else if let str = aString as? NSString {
+            dataSource.document.sendRpcAsync("insert", params: insertedStringToJson(attrStr.string))
+        } else if let str = aString as? String {
             dataSource.document.sendRpcAsync("insert", params: insertedStringToJson(str))
         }
         return NSMakeRange(replacementRange.location, len)

--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -101,11 +101,6 @@ struct GutterCache {
 /// A line-column index into a displayed text buffer.
 typealias BufferPosition = (line: Int, column: Int)
 
-
-func insertedStringToJson(_ stringToInsert: String) -> Any {
-    return ["chars": stringToInsert]
-}
-
 func colorFromArgb(_ argb: UInt32) -> NSColor {
     return NSColor(red: CGFloat((argb >> 16) & 0xff) * 1.0/255,
         green: CGFloat((argb >> 8) & 0xff) * 1.0/255,
@@ -298,9 +293,9 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
             dataSource.document.sendRpcAsync("delete_backward", params  : [])
         }
         if let attrStr = aString as? NSAttributedString {
-            dataSource.document.sendRpcAsync("insert", params: insertedStringToJson(attrStr.string))
+            dataSource.xiView.insert(chars: attrStr.string)
         } else if let str = aString as? String {
-            dataSource.document.sendRpcAsync("insert", params: insertedStringToJson(str))
+            dataSource.xiView.insert(chars: str)
         }
         return NSMakeRange(replacementRange.location, len)
     }

--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -290,7 +290,7 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
             replacementRange.length = 0
         }
         for _ in 0..<aRange.length {
-            dataSource.document.sendRpcAsync("delete_backward", params  : [])
+            dataSource.xiView.deleteBackward()
         }
         if let attrStr = aString as? NSAttributedString {
             dataSource.xiView.insert(chars: attrStr.string)
@@ -316,7 +316,7 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
     func removeMarkedText() {
         if (_markedRange.location != NSNotFound) {
             for _ in 0..<_markedRange.length {
-                dataSource.document.sendRpcAsync("delete_backward", params: [])
+                dataSource.xiView.deleteBackward()
             }
         }
         _markedRange = NSMakeRange(NSNotFound, 0)

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -21,6 +21,7 @@ protocol EditViewDataSource: class {
     var theme: Theme { get }
     var textMetrics: TextDrawingMetrics { get }
     var document: Document! { get }
+    var xiView: XiViewProxy! { get }
     var gutterWidth: CGFloat { get }
     var scrollOrigin: NSPoint { get }
     func maxWidthChanged(toWidth: Double)

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -57,6 +57,8 @@ protocol XiViewProxy: class {
 
     /// Inserts the chars string at the current cursor locations.
     func insert(chars: String)
+    /// Deletes backwards.
+    func deleteBackward()
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -186,6 +188,10 @@ final class XiViewConnection: XiViewProxy {
     func insert(chars: String) {
         let params = ["chars": chars]
         sendRpcAsync("insert", params: params)
+    }
+
+    func deleteBackward() {
+        sendRpcAsync("delete_backward", params: [])
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -54,6 +54,9 @@ protocol XiViewProxy: class {
     func selectionForFind(caseSensitive: Bool)
     /// Sets the current selection as the replacement string.
     func selectionForReplace(caseSensitive: Bool)
+
+    /// Inserts the chars string at the current cursor locations.
+    func insert(chars: String)
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -178,6 +181,11 @@ final class XiViewConnection: XiViewProxy {
         } else {
             return [:]
         }
+    }
+
+    func insert(chars: String) {
+        let params = ["chars": chars]
+        sendRpcAsync("insert", params: params)
     }
 
     private func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -181,6 +181,19 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testInsert() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("insert", method)
+            let insertParams = params as! [String: String]
+            XCTAssertEqual(["chars": "lorem ipsum"], insertParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.insert(chars: "lorem ipsum")
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testSelectionForFindFalse() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params, _ in

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -194,6 +194,19 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testDeleteBackward() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("delete_backward", method)
+            let deleteParams = params as! [String]
+            XCTAssertEqual([], deleteParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.deleteBackward()
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testSelectionForFindFalse() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params, _ in


### PR DESCRIPTION
## Summary
This replaces the remaining `document.sendRpcAsync` calls with `XiViewProxy` method calls in `EditView.swift`.

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.