### PR TITLE
Move scroll RPC method to XiViewProxy

### DIFF
--- a/Sources/XiEditor/Document.swift
+++ b/Sources/XiEditor/Document.swift
@@ -156,7 +156,7 @@ class Document: NSDocument {
     }
 
     func sendWillScroll(first: Int, last: Int) {
-        sendRpcAsync("scroll", params: [first, last])
+        editViewController?.xiView.scroll(firstLine: first, lastLine: last)
     }
 
     func sendPaste(_ pasteString: String) {

--- a/Sources/XiEditor/Document.swift
+++ b/Sources/XiEditor/Document.swift
@@ -159,10 +159,6 @@ class Document: NSDocument {
         editViewController?.xiView.scroll(firstLine: first, lastLine: last)
     }
 
-    func sendPaste(_ pasteString: String) {
-        sendRpcAsync("paste", params: ["chars": pasteString])
-    }
-
     func updateAsync(update: [String: AnyObject]) {
         if let editVC = editViewController {
             editVC.updateAsync(update: update)

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -677,7 +677,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         } else {
             fatalError("insertText: called with undocumented type")
         }
-        document.sendRpcAsync("insert", params: ["chars": text])
+        xiView.insert(chars: text)
     }
 
     // we intercept this method to check if we should open a new tab

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -28,6 +28,12 @@ protocol XiViewProxy: class {
     func copy() -> String?
     func cut() -> String?
 
+    /// Notifies the back-end of the visible scroll region, defined as the first and last
+    /// (non-inclusive) formatted lines. The visible scroll region is used to compute movement
+    /// distance for page up and page down commands, and also controls the size of the fragment
+    /// sent in the update method.
+    func scroll(firstLine: Int, lastLine: Int)
+
     func toggleRecording(name: String)
     func playRecording(name: String)
     func clearRecording(name: String)
@@ -102,6 +108,10 @@ final class XiViewConnection: XiViewProxy {
             print("\(method) failed: \(err)")
             return nil
         }
+    }
+
+    func scroll(firstLine: Int, lastLine: Int) {
+        sendRpcAsync("scroll", params: [firstLine, lastLine])
     }
 
     func toggleRecording(name: String) {

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -77,6 +77,19 @@ class XiViewProxyTests: XCTestCase {
         XCTAssertEqual(result!, testCopyCharacters)
     }
 
+    func testScroll() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, params, _ in
+            XCTAssertEqual("scroll", method)
+            let scrollParams = params as! [Int]
+            XCTAssertEqual([23, 42], scrollParams)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.scroll(firstLine: 23, lastLine: 42)
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     func testToggleRecording() {
         let asyncCalledExpectation = expectation(description: "Async should be called")
         let async: XiViewConnection.AsyncRpc = { method, params,_ in


### PR DESCRIPTION
## Summary
- move "scroll" to `XiViewProxy`
- remove unused `sendPaste` method
- use `insert` from `XiViewProxy`

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
