### PR TITLE
Fix case sensitivity selection for find and rename ignorecase

### DIFF
--- a/Sources/XiEditor/Main.storyboard
+++ b/Sources/XiEditor/Main.storyboard
@@ -443,10 +443,10 @@ Gw
                 </viewController>
                 <menu title="Find Menu" autoenablesItems="NO" id="RHe-lc-wA0">
                     <items>
-                        <menuItem title="Ignore Case" state="on" tag="101" id="kHJ-AD-dbh">
+                        <menuItem title="Case Sensitive" tag="101" id="kHJ-AD-dbh">
                             <modifierMask key="keyEquivalentModifierMask"/>
                             <connections>
-                                <action selector="selectIgnoreCaseMenuAction:" target="uoL-yg-E2H" id="gmM-OH-nDw"/>
+                                <action selector="selectCaseSensitiveMenuAction:" target="uoL-yg-E2H" id="wnU-1k-TRL"/>
                             </connections>
                         </menuItem>
                         <menuItem title="Wrap Around" state="on" tag="102" id="EJI-Cs-6OX">

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -190,7 +190,7 @@ class SuplementaryFindViewController: NSViewController, NSSearchFieldDelegate, N
     let resultCountLabel = Label(title: "")
 
     // assigned in IB
-    let ignoreCaseMenuTag = 101
+    let caseSensitiveMenuTag = 101
     let wrapAroundMenuTag = 102
     let regexMenuTag = 103
     let wholeWordsMenuTag = 104
@@ -229,8 +229,8 @@ class SuplementaryFindViewController: NSViewController, NSSearchFieldDelegate, N
     // we use this to make sure that UI corresponds to our state
     override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.tag {
-        case ignoreCaseMenuTag:
-            menuItem.state = !caseSensitive ? .on : .off
+        case caseSensitiveMenuTag:
+            menuItem.state = caseSensitive ? .on : .off
         case wrapAroundMenuTag:
             menuItem.state = wrapAround ? .on : .off
         case regexMenuTag:
@@ -274,7 +274,7 @@ class SuplementaryFindViewController: NSViewController, NSSearchFieldDelegate, N
         parentFindView?.redoFind()
     }
 
-    @IBAction func selectIgnoreCaseMenuAction(_ sender: NSMenuItem) {
+    @IBAction func selectCaseSensitiveMenuAction(_ sender: NSMenuItem) {
         caseSensitive = !caseSensitive
         parentFindView?.redoFind()
     }

--- a/Sources/XiEditor/Search.swift
+++ b/Sources/XiEditor/Search.swift
@@ -196,7 +196,7 @@ class SuplementaryFindViewController: NSViewController, NSSearchFieldDelegate, N
     let wholeWordsMenuTag = 104
     let removeMenuTag = 105
 
-    var ignoreCase = true
+    var caseSensitive = false
     var wrapAround = true
     var regex = false
     var wholeWords = false
@@ -230,7 +230,7 @@ class SuplementaryFindViewController: NSViewController, NSSearchFieldDelegate, N
     override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.tag {
         case ignoreCaseMenuTag:
-            menuItem.state = ignoreCase ? .on : .off
+            menuItem.state = !caseSensitive ? .on : .off
         case wrapAroundMenuTag:
             menuItem.state = wrapAround ? .on : .off
         case regexMenuTag:
@@ -275,7 +275,7 @@ class SuplementaryFindViewController: NSViewController, NSSearchFieldDelegate, N
     }
 
     @IBAction func selectIgnoreCaseMenuAction(_ sender: NSMenuItem) {
-        ignoreCase = !ignoreCase
+        caseSensitive = !caseSensitive
         parentFindView?.redoFind()
     }
 
@@ -308,7 +308,7 @@ class SuplementaryFindViewController: NSViewController, NSSearchFieldDelegate, N
         return FindQuery(
             id: id,
             term: searchField.stringValue,
-            caseSensitive: !ignoreCase,
+            caseSensitive: caseSensitive,
             regex: regex,
             wholeWords: wholeWords
         )
@@ -395,7 +395,7 @@ extension EditViewController {
             }
 
             if firstStatus.caseSensitive != nil {
-                query?.ignoreCase = !(statusQuery.caseSensitive != nil)
+                query?.caseSensitive = (statusQuery.caseSensitive != nil && statusQuery.caseSensitive!)
             }
 
             if firstStatus.wholeWords != nil {


### PR DESCRIPTION
There was a small bug where the `case_sensitive` parameter in `find_status` was not parsed correctly.
Fixing this also made me rename `ignoreCase` to `caseSensitive` since it became quite confusing.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
