### PR TITLE
Make use of spaces explicit in project setting

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 				AE499DCD1C82BB2B002D68AF /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		AE499DCD1C82BB2B002D68AF /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
This is a tiny PR to make the Spaces/Tabs setting explicit in the project. Right now the project doesn't specify it and so for folks who have Xcode set to use Spaces in their preferences, everything just works. But if anyone has the Xcode preference set to use Tabs, then Xcode applies that setting to the Xi-Editor project and it results in lots of spaces changed to tabs in PRs. Not good. 

So this makes it explicit. This shouldn't result in any actual changes for anyone.

Related to #448