### PR TITLE
Fix CLI waiting for files involving symlinks

### DIFF
--- a/Sources/XiCliCore/CommandLineTool.swift
+++ b/Sources/XiCliCore/CommandLineTool.swift
@@ -63,23 +63,7 @@ public final class CommandLineTool {
             }
         }
         
-        if input.hasPrefix("/") {
-            filePath = URL(fileURLWithPath: input)
-        } else if input.hasPrefix("~") {
-            var input = input
-            input.remove(at: input.startIndex)
-            if #available(OSX 10.12, *) {
-                filePath = fileManager.homeDirectoryForCurrentUser
-            } else {
-                filePath = URL(fileURLWithPath: NSHomeDirectory())
-            }
-            filePath.appendPathComponent(input)
-        } else {
-            let basePath = URL(fileURLWithPath: fileManager.currentDirectoryPath)
-            filePath = basePath.appendingPathComponent(input)
-        }
-        
-        let pathString = filePath.path
+        let pathString = canonicalPath(input)
 
         guard pathIsNotDirectory(pathString) else {
             throw CliError.pathIsDirectory
@@ -116,7 +100,7 @@ public final class CommandLineTool {
 
         var filePaths = filePaths
         notificationCenter.addObserver(forName: notification, object: nil, queue: notificationQueue) { notification in
-            let passedPath = notification.userInfo!["path"] as! String
+            let passedPath = self.canonicalPath(notification.userInfo!["path"] as! String)
             if let index = filePaths.index(of: passedPath) {
                 filePaths.remove(at: index)
             }
@@ -142,6 +126,10 @@ public final class CommandLineTool {
                     prints this
                 """
         print(message)
+    }
+
+    func canonicalPath(_ path: String) -> String {
+        return URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
     }
 }
 


### PR DESCRIPTION
## Summary

When a file had a symlink in it's path, the path returned from `resolvePath` didn't match the path returned from the observer. This change introduces a common method for canonicalizing file paths in
both places.

Fixes https://github.com/xi-editor/xi-editor/issues/1143

## Questions

This is the first time I've done any Mac/Swift/Xi development. As such, I'm not sure my approach is ideal and I have the following questions about my changes:

* I have simplified the resolving code. I think this still handles the existing cases correctly but am I missing something?
* I wasn't sure whether to limit my changes to the observer code. Canonicalising both the input and observer paths seems fine to me, but perhaps doing this on the inputs could cause issues elsewhere?

## Review Checklist

- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
