### PR TITLE
Move selection transformation RPC methods to XiViewproxy

### DIFF
--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -493,7 +493,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     override func lowercaseWord(_ sender: Any?) {
-        document.sendRpcAsync("lowercase", params: [])
+        xiView.lowercase()
     }
 
     override func capitalizeWord(_ sender: Any?) {

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -497,7 +497,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     override func capitalizeWord(_ sender: Any?) {
-        document.sendRpcAsync("capitalize", params: [])
+        xiView.capitalize()
     }
 
     @objc func undo(_ sender: AnyObject?) {

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -523,7 +523,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     @objc func unindent(_ sender: Any?) {
-        document.sendRpcAsync("outdent", params: [])
+        xiView.outdent()
     }
 
     @objc func reindent(_ sender: Any?) {

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -527,7 +527,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     @objc func reindent(_ sender: Any?) {
-        document.sendRpcAsync("reindent", params: [])
+        xiView.reindent()
     }
 
     @objc func increaseNumber(_ sender: Any?) {

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -519,7 +519,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     override func indent(_ sender: Any?) {
-        document.sendRpcAsync("indent", params: [])
+        xiView.indent()
     }
 
     @objc func unindent(_ sender: Any?) {

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -489,7 +489,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     override func uppercaseWord(_ sender: Any?) {
-        document.sendRpcAsync("uppercase", params: [])
+        xiView.uppercase()
     }
 
     override func lowercaseWord(_ sender: Any?) {

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -71,6 +71,7 @@ protocol XiViewProxy: class {
     func uppercase()
     func lowercase()
     func capitalize()
+    func indent()
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -154,6 +155,10 @@ final class XiViewConnection: XiViewProxy {
 
     func capitalize() {
         sendRpcAsync("capitalize", params: [])
+    }
+
+    func indent() {
+        sendRpcAsync("indent", params: [])
     }
 
     /// All parameters are optional. Boolean parameters are by default `false` and `modify_selection` is `set` by default.

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -72,6 +72,7 @@ protocol XiViewProxy: class {
     func lowercase()
     func capitalize()
     func indent()
+    func outdent()
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -159,6 +160,10 @@ final class XiViewConnection: XiViewProxy {
 
     func indent() {
         sendRpcAsync("indent", params: [])
+    }
+
+    func outdent() {
+        sendRpcAsync("outdent", params: [])
     }
 
     /// All parameters are optional. Boolean parameters are by default `false` and `modify_selection` is `set` by default.

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -65,6 +65,10 @@ protocol XiViewProxy: class {
     func insert(chars: String)
     /// Deletes backwards.
     func deleteBackward()
+
+    /// transformations
+    /// The following methods act by modifying the current selection.
+    func uppercase()
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -134,6 +138,12 @@ final class XiViewConnection: XiViewProxy {
     func findNext(wrapAround: Bool, allowSame: Bool, modifySelection: SelectionModifier) {
         let params = createFindParamsFor(wrapAround: wrapAround, allowSame: allowSame, modifySelection: modifySelection)
         sendRpcAsync("find_next", params: params)
+    }
+
+    // MARK: - transformations
+
+    func uppercase() {
+        sendRpcAsync("uppercase", params: [])
     }
 
     /// All parameters are optional. Boolean parameters are by default `false` and `modify_selection` is `set` by default.

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -69,6 +69,7 @@ protocol XiViewProxy: class {
     /// transformations
     /// The following methods act by modifying the current selection.
     func uppercase()
+    func lowercase()
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -144,6 +145,10 @@ final class XiViewConnection: XiViewProxy {
 
     func uppercase() {
         sendRpcAsync("uppercase", params: [])
+    }
+
+    func lowercase() {
+        sendRpcAsync("lowercase", params: [])
     }
 
     /// All parameters are optional. Boolean parameters are by default `false` and `modify_selection` is `set` by default.

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -70,6 +70,7 @@ protocol XiViewProxy: class {
     /// The following methods act by modifying the current selection.
     func uppercase()
     func lowercase()
+    func capitalize()
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -149,6 +150,10 @@ final class XiViewConnection: XiViewProxy {
 
     func lowercase() {
         sendRpcAsync("lowercase", params: [])
+    }
+
+    func capitalize() {
+        sendRpcAsync("capitalize", params: [])
     }
 
     /// All parameters are optional. Boolean parameters are by default `false` and `modify_selection` is `set` by default.

--- a/Sources/XiEditor/XiViewProxy.swift
+++ b/Sources/XiEditor/XiViewProxy.swift
@@ -73,6 +73,7 @@ protocol XiViewProxy: class {
     func capitalize()
     func indent()
     func outdent()
+    func reindent()
 }
 
 final class XiViewConnection: XiViewProxy {
@@ -164,6 +165,10 @@ final class XiViewConnection: XiViewProxy {
 
     func outdent() {
         sendRpcAsync("outdent", params: [])
+    }
+
+    func reindent() {
+        sendRpcAsync("reindent", params: [])
     }
 
     /// All parameters are optional. Boolean parameters are by default `false` and `modify_selection` is `set` by default.

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -436,5 +436,16 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testCapitalize() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, _, _ in
+            XCTAssertEqual("capitalize", method)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.capitalize()
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     private let unusedSync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
 }

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -447,5 +447,16 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testIndent() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, _, _ in
+            XCTAssertEqual("indent", method)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.indent()
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     private let unusedSync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
 }

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -414,5 +414,16 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testUppercase() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, _, _ in
+            XCTAssertEqual("uppercase", method)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.uppercase()
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     private let unusedSync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
 }

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -458,5 +458,16 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testOutdent() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, _, _ in
+            XCTAssertEqual("outdent", method)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.outdent()
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     private let unusedSync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
 }

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -469,5 +469,16 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testReindent() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, _, _ in
+            XCTAssertEqual("reindent", method)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.reindent()
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     private let unusedSync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
 }

--- a/Tests/XiEditorTests/XiViewProxyTests.swift
+++ b/Tests/XiEditorTests/XiViewProxyTests.swift
@@ -425,5 +425,16 @@ class XiViewProxyTests: XCTestCase {
         wait(for: [asyncCalledExpectation], timeout: 1)
     }
 
+    func testLowercase() {
+        let asyncCalledExpectation = expectation(description: "Async should be called")
+        let async: XiViewConnection.AsyncRpc = { method, _, _ in
+            XCTAssertEqual("lowercase", method)
+            asyncCalledExpectation.fulfill()
+        }
+        let connection: XiViewProxy = XiViewConnection(asyncRpc: async, syncRpc: unusedSync)
+        connection.lowercase()
+        wait(for: [asyncCalledExpectation], timeout: 1)
+    }
+
     private let unusedSync: XiViewConnection.SyncRpc = { _,_ in return .ok("not implemented in tests" as AnyObject) }
 }


### PR DESCRIPTION
## Summary
Move selection transformation RPC methods to XiViewproxy

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
