### PR TITLE
Fix janky scrolling on external mice

### DIFF
--- a/Sources/XiEditor/XiClipView.swift
+++ b/Sources/XiEditor/XiClipView.swift
@@ -21,8 +21,13 @@ protocol ScrollInterested: class {
 class XiClipView: NSClipView {
     weak var delegate: ScrollInterested?
 
+    // Smooth scrolling (like the MacBook trackpad or Apple Magic Mouse) sends scroll events that are chunked, continuous and cumulative, 
+    // and thus the scroll view's clipView's bounds is set properly (in small increments) for each of these small chunks of scrolling. 
+    // Scrolling with notched mice scrolls in discrete units, takes into account acceleration but does not redraw the view when the view is continuously redrawn (like in xi-mac) during scrolling. 
+    // This is because the bounds origin is only set after the scrolling has stopped completely.
+    // We bypass this by simply setting the bound origin immediately. 
     override func scroll(to newOrigin: NSPoint) {
         delegate?.willScroll(to: newOrigin)
-        super.scroll(to: newOrigin)
+        super.setBoundsOrigin(newOrigin)
     }
 }


### PR DESCRIPTION
## Summary
This fixes an issue where the `scroll(to: NSPoint)` usage in xi-mac's case _only_ supports smooth scrolling
and thus doesn't properly take into account notched mouse wheel scroll (which usually means external mice).

Smooth scrolling (like the MacBook trackpad or Apple Magic Mouse) sends scrollEvents that are chunked, continuous and cumulative, and thus the scroll view's `clipView`'s bounds is set properly for each of these small chunks of scrolling. 

Scrolling with notched mice scrolls in discrete units, takes into account acceleration but does not redraw the view when the view is continuously redrawn during scrolling - this is because the bounds origin is only set after the scrolling has stopped completely, causing the janky scroll that is described in #411. This is likely a bug/oversight on Apple's part.

This PR simply sets the `clipView`'s bound origin properly on all scrolling.

closes #411.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.