### PR TITLE
Remove old tmp log

### DIFF
--- a/Sources/XiEditor/AppDelegate.swift
+++ b/Sources/XiEditor/AppDelegate.swift
@@ -123,9 +123,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return applicationDirectory
     }()
 
-    // The default name for XiEditor's error logs
-    let defaultCoreLogName = "xi_tmp.log"
-
     lazy var errorLogDirectory: URL? = {
         let logDirectory = FileManager.default.urls(
             for: .libraryDirectory,
@@ -189,17 +186,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Set Cli Menu Title
         renameCliToggle()
-    }
-    
-    // Clean up temporary Xi stderr log
-    func applicationWillTerminate(_ notification: Notification) {
-        if let tmpErrLogFile = errorLogDirectory?.appendingPathComponent(defaultCoreLogName) {
-            do {
-                try FileManager.default.removeItem(at: tmpErrLogFile)
-            } catch let err as NSError {
-                print("Failed to remove temporary log file. \(err)")
-            }
-        }
     }
     
     // MARK: - CLI Menu Items


### PR DESCRIPTION
We don't use this `xi_tmp.log` file anymore, so there's no need to have these in.

## Review Checklist
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
