### PR TITLE
Fix scrollers not appearing for certain settings

### DIFF
--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -325,6 +325,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         if first..<last != visibleLines {
             document.sendWillScroll(first: first, last: last)
             visibleLines = first..<last
+
+            // Cancels the scroll animation to prevent jerky scrolling.
+            scrollView.contentView.setBoundsOrigin(newOrigin)
         }
         editView.needsDisplay = true
     }

--- a/Sources/XiEditor/XiClipView.swift
+++ b/Sources/XiEditor/XiClipView.swift
@@ -21,13 +21,8 @@ protocol ScrollInterested: class {
 class XiClipView: NSClipView {
     weak var delegate: ScrollInterested?
 
-    // Smooth scrolling (like the MacBook trackpad or Apple Magic Mouse) sends scroll events that are chunked, continuous and cumulative, 
-    // and thus the scroll view's clipView's bounds is set properly (in small increments) for each of these small chunks of scrolling. 
-    // Scrolling with notched mice scrolls in discrete units, takes into account acceleration but does not redraw the view when the view is continuously redrawn (like in xi-mac) during scrolling. 
-    // This is because the bounds origin is only set after the scrolling has stopped completely.
-    // We bypass this by simply setting the bound origin immediately. 
     override func scroll(to newOrigin: NSPoint) {
         delegate?.willScroll(to: newOrigin)
-        super.setBoundsOrigin(newOrigin)
+        super.scroll(to: newOrigin)
     }
 }


### PR DESCRIPTION
## Summary
On certain setups, scrollers were not appearing on scroll due to `XiClipView`'s `scroll(to: NSPoint)` declaration overriding the Apple's scroller management code.
This commit fixes that by calling `super.scroll(to: )` to access the scroller management, and calling `setBoundsOrigin` from `EditViewController`.

Note that this is a bit of a hacky fix - the real fix would probably involve figuring out how to make `XiTextPlane` responsively render on notched mouse scroll, perhaps implementing `prepareContentInRect`, though I'm not quite sure if it would do the job.
![Kapture 2019-09-23 at 22 38 43](https://user-images.githubusercontent.com/12481747/65440484-fde77600-de52-11e9-9482-313633ebf1e4.gif)

## Related Issues
Closes #476 

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
