### PR TITLE
Bugfix: line invalidation for update with no operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
   - osx
 
 rust:
-  - 1.31.0
+  - stable
 
 cache: cargo
 

--- a/Sources/XiEditor/LineCache.swift
+++ b/Sources/XiEditor/LineCache.swift
@@ -106,6 +106,12 @@ fileprivate class LineCacheState<T>: UnfairLock {
         annotations = AnnotationStore(from: params.annotations)
 
         let inval = InvalSet()
+        
+        if params.ops.isEmpty {
+            // do not invalidate lines if only there are no update operations, e.g. when only updating annotations
+            return inval
+        }
+        
         let oldHeight = height
         var newInvalidBefore = 0
         var newLines: [Line<T>?] = []

--- a/Tests/IntegrationTests/SearchIntegrationTests.swift
+++ b/Tests/IntegrationTests/SearchIntegrationTests.swift
@@ -26,65 +26,70 @@ class SearchIntegrationTests: XCTestCase {
     }
 
     func testSearchingGoldenBoys() {
-        let findExpectation = expectation(description: "find expectation")
+        weak var findExpectation = expectation(description: "find expectation")
         let findAction: TestClientImplementation.FindStatusAction = { status in
             XCTAssertEqual(2, status.count)
             XCTAssertEqual(67, status[0].matches)
             XCTAssertEqual(202, status[1].matches)
-            findExpectation.fulfill()
+            findExpectation?.fulfill()
+            findExpectation = nil
         }
         searchTester = SearchTester(findAction: findAction)
         searchGoldenBoys(for: ["Golden", "Boys"])
-        wait(for: [findExpectation], timeout: 5)
+        wait(for: [findExpectation!], timeout: 5)
     }
 
     func testSearchingGoldenBoysCaseSensitive() {
-        let findExpectation = expectation(description: "find expectation")
+        weak var findExpectation = expectation(description: "find expectation")
         let findAction: TestClientImplementation.FindStatusAction = { status in
             XCTAssertEqual(2, status.count)
             XCTAssertEqual(52, status[0].matches)
             XCTAssertEqual(33, status[1].matches)
-            findExpectation.fulfill()
+            findExpectation!.fulfill()
+            findExpectation = nil
         }
         searchTester = SearchTester(findAction: findAction)
         searchGoldenBoys(for: ["Golden", "Boys"], caseSensitive: true)
-        wait(for: [findExpectation], timeout: 5)
+        wait(for: [findExpectation!], timeout: 5)
     }
 
     func testSearchingKernertok() {
-        let findExpectation = expectation(description: "find expectation")
+        weak var findExpectation = expectation(description: "find expectation")
         let findAction: TestClientImplementation.FindStatusAction = { status in
             XCTAssertEqual(1, status.count)
             XCTAssertEqual(26 , status[0].matches)
-            findExpectation.fulfill()
+            findExpectation?.fulfill()
+            findExpectation = nil
         }
         searchTester = SearchTester(findAction: findAction)
         searchGoldenBoys(for: ["Kernertok"])
-        wait(for: [findExpectation], timeout: 5)
+        wait(for: [findExpectation!], timeout: 5)
     }
 
     func testSearchingThe() {
-        let findExpectation = expectation(description: "find expectation")
+        weak var findExpectation = expectation(description: "find expectation")
         let findAction: TestClientImplementation.FindStatusAction = { status in
             XCTAssertEqual(1, status.count)
             XCTAssertEqual(5764, status[0].matches)
-            findExpectation.fulfill()
+            findExpectation?.fulfill()
+            findExpectation = nil
         }
         searchTester = SearchTester(findAction: findAction)
         searchGoldenBoys(for: ["the"])
-        wait(for: [findExpectation], timeout: 5)
+        wait(for: [findExpectation!], timeout: 5)
     }
 
     func testSearchingTheCaseSensitive() {
-        let findExpectation = expectation(description: "find expectation")
+        weak var findExpectation = expectation(description: "find expectation")
         let findAction: TestClientImplementation.FindStatusAction = { status in
             XCTAssertEqual(1, status.count)
             XCTAssertEqual(407, status[0].matches)
-            findExpectation.fulfill()
+            findExpectation?.fulfill()
+            findExpectation = nil
         }
         searchTester = SearchTester(findAction: findAction)
         searchGoldenBoys(for: ["The"], caseSensitive: true)
-        wait(for: [findExpectation], timeout: 5)
+        wait(for: [findExpectation!], timeout: 5)
     }
 
     private func searchGoldenBoys(for terms: [String], caseSensitive: Bool = false) {
@@ -98,7 +103,7 @@ class SearchIntegrationTests: XCTestCase {
         let testBundle = Bundle(for: type(of: self))
         guard let filePath = testBundle.url(forResource: "the-golden-boys", withExtension: "txt")?.path
             else { fatalError("Xi test bundle is missing the-golden-boys.txt") }
-
+        
         searchTester?.search(filePath: filePath, for: queries)
     }
 }


### PR DESCRIPTION
This is required to support changes made in https://github.com/xi-editor/xi-editor/pull/1236

Without this fix there are line invalidation issues.