### PR TITLE
480 Drag events cause file to be opened

### DIFF
--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -224,11 +224,17 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         return true
     }
 
-    override func draggingEnded(_ sender: NSDraggingInfo) {
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        return sender.draggingSourceOperationMask.intersection([.generic])
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         // open file dragged into window
         guard let pasteboard = sender.draggingPasteboard.propertyList(forType: NSPasteboard.PasteboardType(rawValue: "NSFilenamesPboardType")) as? NSArray,
             let path = pasteboard.firstObject as? String
-        else { return }
+        else {
+            return false
+        }
 
         NSDocumentController.shared.openDocument(
             withContentsOf: URL.init(fileURLWithPath: path),
@@ -238,6 +244,7 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
                     print("error opening file \(error)")
                 }
         })
+        return true
     }
 
     /// Resets the blink timer, if the cursor should be blinking


### PR DESCRIPTION
<!---
Welcome to the xi-mac front end of the xi-editor project! We're very excited for your contribution to become a part of the editor.
This template provides some basic instructions on how to format a pull request, so we can more easily understand it.
Anything within this commented block will not be a part of the visible text.

The first part of your pull request should be a summary describing its intent. This is also an appropriate place to explain the motivation behind the changes it introduces.
--->
## Summary
#480  Drag events cause file to be opened

Issue:
* Files dragged over XiEditor window and dropped elsewhere is opened by XiEditor.
* This is becasue file open is triggered from draggingEnded(_:) which is invoked immeterial of drop location

Fix:
* Use draggingEntered(_:) to return the dragging operation that XiEditor will perform when dropped
* Trigger file open from performDragOperation(_:) delegate callback

<!---
Give reviewers and interested parties a good idea of how this is related to other issues or pull requests.
--->
## Related Issues
closes #480

<!---
Checklists are a useful tool for tracking your progress with longer pull requests. It gives reviewers a clear idea of how far you've come, and what can be reviewed. It's also fun to check off those boxes!
--->
## Checklist
Example:

- [ ] Example check-list item
- [x] Create a pull request template
- [ ] make xi perfect

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-mac/master.
