### PR TITLE
460 xi --wait does not return after application exit

### DIFF
--- a/Sources/XiEditor/Document.swift
+++ b/Sources/XiEditor/Document.swift
@@ -96,6 +96,7 @@ class Document: NSDocument {
             xiCore.closeView(identifier: identifier)
         }
         super.close()
+        editViewController?.postDocumentClosedNotification()
     }
 
     override var isEntireFileLoaded: Bool {

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -966,6 +966,12 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     @IBAction func duplicateLine(_ sender: NSMenuItem) {
         document.sendRpcAsync("duplicate_line", params: [])
     }
+    
+    func postDocumentClosedNotification() {
+        let path = self.document.fileURL?.path // To check if window contains file opened by cli
+        let notification = Notification.Name("io.xi-editor.XiEditor.FileClosed")
+        DistributedNotificationCenter.default().post(name: notification, object: nil, userInfo: ["path": path ?? "FILE_NOT_SAVED"])
+    }
 }
 
 // we set this in Document.swift when we load a new window or tab.
@@ -978,13 +984,6 @@ extension EditViewController: NSWindowDelegate {
 
     func windowDidResignKey(_ notification: Notification) {
         editView.isFrontmostView = false
-    }
-    
-    @objc func windowShouldClose(_ sender: NSWindow) -> Bool {
-        let path = self.document.fileURL?.path // To check if window contains file opened by cli
-        let notification = Notification.Name("io.xi-editor.XiEditor.FileClosed")
-        DistributedNotificationCenter.default().post(name: notification, object: nil, userInfo: ["path": path ?? "FILE_NOT_SAVED"])
-        return true
     }
 }
 


### PR DESCRIPTION
Summary
Issue:
https://github.com/xi-editor/xi-mac/issues/460  xi --wait does not return after application exit

CLI xi --wait does not exit when the XiEditor app is killed using CMD+Q

XiEditor posts "io.xi-editor.XiEditor.FileClosed" notification on windowShouldClose(_ sender:) which is invoked whenever window is closed. But this delegate is not
invoked when the app is killed using CMD+Q

Fix:
NSDocument invokes close() on both app termination and window close so, instead of windowShouldClose(_ sender:) rely on NSDocument's close() method to post "io.xi-editor.XiEditor.FileClosed" notification

Now Xi CLI should stop waiting both on closing a window and on app exit(CMD+Q)


<!---
Give reviewers and interested parties a good idea of how this is related to other issues or pull requests.
--->
## Related Issues
closes #460 

<!---
Checklists are a useful tool for tracking your progress with longer pull requests. It gives reviewers a clear idea of how far you've come, and what can be reviewed. It's also fun to check off those boxes!
--->
## Checklist
Example:

- [ ] Example check-list item
- [x] Create a pull request template
- [ ] make xi perfect

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-mac/master.
