### PR TITLE
Fix status bar hiding first line when shown

### DIFF
--- a/Sources/XiEditor/EditView.swift
+++ b/Sources/XiEditor/EditView.swift
@@ -383,7 +383,7 @@ final class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
     }
 
     func yOffsetToLine(_ y: CGFloat) -> Int {
-        let y = max(y - dataSource.textMetrics.topPadding, 0)
+        let y = max(y - dataSource.textMetrics.topPadding - self.frame.origin.y, 0)
         return Int(floor(y / dataSource.textMetrics.linespace))
     }
 


### PR DESCRIPTION
This was caused by not accounting for the status bar's frame during line calculation.

Fixes #487 

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-mac/master.
